### PR TITLE
Fix 05-config.yaml to be a list

### DIFF
--- a/manifests/05-config.yaml
+++ b/manifests/05-config.yaml
@@ -1,3 +1,6 @@
+apiVersion: v1
+kind: List
+items:
 - apiVersion: v1
   kind: ConfigMap
   metadata:


### PR DESCRIPTION
Was missing some keys in 05-config.yaml that prevented creation with oc create -f.