### PR TITLE
Migrate to unique PagerDuty service names

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_created.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_created.go
@@ -37,7 +37,8 @@ func (r *ReconcileClusterDeployment) handleCreate(request reconcile.Request, ins
 	}
 
 	pdData := &pd.Data{
-		ClusterID: instance.Name,
+		ClusterID:  instance.Spec.ClusterName,
+		BaseDomain: instance.Spec.BaseDomain,
 	}
 	pdData.ParsePDConfig(r.client)
 	pdServiceID, err := pdData.CreateService()

--- a/pkg/controller/clusterdeployment/clusterdeployment_deleted.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_deleted.go
@@ -39,7 +39,8 @@ func (r *ReconcileClusterDeployment) handleDelete(request reconcile.Request, ins
 	}
 
 	pdData := &pd.Data{
-		ClusterID: instance.Name,
+		ClusterID:  instance.Spec.ClusterName,
+		BaseDomain: instance.Spec.BaseDomain,
 	}
 	err = pdData.ParsePDConfig(r.client)
 	if err != nil {

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -59,6 +59,7 @@ type Data struct {
 	servicePrefix      string
 	APIKey             string
 	ClusterID          string
+	BaseDomain         string
 }
 
 // ParsePDConfig parses the PD Config map and stores it in the struct
@@ -110,7 +111,7 @@ func (data *Data) ParsePDConfig(osc client.Client) error {
 func (data *Data) GetService() (string, error) {
 	client := pdApi.NewClient(data.APIKey)
 	var opts pdApi.ListServiceOptions
-	opts.Query = data.servicePrefix + "-" + data.ClusterID + "-hive-cluster"
+	opts.Query = data.servicePrefix + "-" + data.ClusterID + "." + data.BaseDomain + "-hive-cluster"
 	services, err := client.ListServices(opts)
 	if err != nil {
 		return "", err
@@ -135,7 +136,7 @@ func (data *Data) CreateService() (string, error) {
 	}
 
 	clusterService := pdApi.Service{
-		Name:                   data.servicePrefix + "-" + data.ClusterID + "-hive-cluster",
+		Name:                   data.servicePrefix + "-" + data.ClusterID + "." + data.BaseDomain + "-hive-cluster",
 		Description:            data.ClusterID + " - A managed hive created cluster",
 		EscalationPolicy:       *escalationPolicy,
 		AutoResolveTimeout:     &data.autoResolveTimeout,


### PR DESCRIPTION
Make the PagerDuty Service name unique across all hive instances.
On SyncSet delete try and get the service first, if that fails create a
new PagerDuty Service.

We need to make sure that the PagerDuty Service names are unique across all hive instances. Also on SyncSet delete we should try running a GetService first, if that fails run a CreateService. This  is useful in the initial migration to unique service names

/cc @jharrington22 
/cc @jewzaam 