### PR TITLE
Fix a couple edge cases

### DIFF
--- a/pkg/controller/syncset/syncset_deleted.go
+++ b/pkg/controller/syncset/syncset_deleted.go
@@ -50,12 +50,11 @@ func (r *ReconcileSyncSet) recreateSyncSet(request reconcile.Request) (reconcile
 		var createErr error
 		pdServiceID, createErr = pdData.CreateService()
 		if createErr != nil {
-			return reconcile.Result{}, err
+			return reconcile.Result{}, createErr
 		}
-
 	}
 
-	newSS := pdData.GenerateSyncSet(request.Namespace, strings.Split(request.Name, "-")[0], pdServiceID)
+	newSS := pdData.GenerateSyncSet(request.Namespace, clusterdeployment.Name, pdServiceID)
 
 	if err := r.client.Create(context.TODO(), newSS); err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
During migration to the new pagerduty service name I hit a few edge cases. This should solve them.

Edge Cases Fixed:

- If the syncset is deleted and a new operator is rolled out, it does not know how to handle reconciling them since they have the finalizer, I changed how I set the finalizer, and then I run a GetService instead of just create, so it will check to see if any existing PD Services exist and reuse that before creating a new service

- Fixed the case of the CD name being different from the clusterid in the syncset. It seems that the cluster deployment does not need to share the same name as the cluster id, so I am passing in the correct name for the ClusterID to the syncset.

/cc @jewzaam 
/cc @lisa 