### PR TITLE
Allow deletion of syncsets

### DIFF
--- a/manifests/02-role.yaml
+++ b/manifests/02-role.yaml
@@ -57,3 +57,4 @@ rules:
   - syncsets
   verbs:
   - create
+  - delete


### PR DESCRIPTION
We were missing the delete permissions on syncsets.