### PR TITLE
Deploy needed objects for prometheus metrics when the operator comes up

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,11 +23,13 @@ import (
 
 	"github.com/openshift/pagerduty-operator/pkg/apis"
 	"github.com/openshift/pagerduty-operator/pkg/controller"
+	operatormetrics "github.com/openshift/pagerduty-operator/pkg/metrics"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
-	"github.com/operator-framework/operator-sdk/pkg/metrics"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -112,6 +114,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := monitoringv1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "error registering prometheus monitoring objects")
+		os.Exit(1)
+	}
+
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
 		log.Error(err, "")
@@ -119,10 +126,23 @@ func main() {
 	}
 
 	// Create Service object to expose the metrics port.
-	_, err = metrics.ExposeMetricsPort(ctx, metricsPort)
+	s, _ := operatormetrics.GenerateService(8080, "metrics")
+	sm := operatormetrics.GenerateServiceMonitor(s)
+	err = mgr.GetClient().Create(context.TODO(), s)
 	if err != nil {
-		log.Info(err.Error())
+		log.Error(err, "error creating metrics Service")
+	} else {
+		log.Info("Created Service")
+		err = mgr.GetClient().Create(context.TODO(), sm)
+		if err != nil {
+			log.Error(err, "error creating metrics ServiceMonitor")
+		} else {
+			log.Info("Created ServiceMonitor")
+		}
 	}
+
+	log.Info("Starting prometheus metrics")
+	operatormetrics.StartMetrics()
 
 	log.Info("Starting the Cmd.")
 

--- a/manifests/06-prometheus-k8s-role.yaml
+++ b/manifests/06-prometheus-k8s-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/07-prometheus-k8s-rolebinding.yaml
+++ b/manifests/07-prometheus-k8s-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+roleRef:
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,63 @@
+// Copyright 2019 RedHat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// MetricsEndpoint is the port to export metrics on
+	MetricsEndpoint = ":8080"
+)
+
+var (
+	metricPlaceholder = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "placeholder",
+		Help: "Placeholder",
+	}, []string{"name"})
+
+	metricsList = []prometheus.Collector{
+		metricPlaceholder,
+	}
+)
+
+// StartMetrics register metrics and exposes them
+func StartMetrics() {
+
+	// Register metrics and start serving them on /metrics endpoint
+	RegisterMetrics()
+	http.Handle("/metrics", prometheus.Handler())
+	go http.ListenAndServe(MetricsEndpoint, nil)
+}
+
+// RegisterMetrics for the operator
+func RegisterMetrics() error {
+	for _, metric := range metricsList {
+		err := prometheus.Register(metric)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UpdatePlaceholderGauge ...
+func UpdatePlaceholderGauge() {
+
+	metricPlaceholder.With(prometheus.Labels{"name": "pagerduty-operator"}).Set(float64(1))
+}

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -1,0 +1,92 @@
+// Copyright 2019 RedHat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// GenerateService returns the static service which exposes specifed port.
+func GenerateService(port int32, portName string) (*v1.Service, error) {
+	operatorName, err := k8sutil.GetOperatorName()
+	if err != nil {
+		return nil, err
+	}
+	namespace, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return nil, err
+	}
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operatorName,
+			Namespace: namespace,
+			Labels:    map[string]string{"name": operatorName},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Port:     port,
+					Protocol: v1.ProtocolTCP,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: port,
+					},
+					Name: portName,
+				},
+			},
+			Selector: map[string]string{"name": operatorName},
+		},
+	}
+	return service, nil
+}
+
+// GenerateServiceMonitor generates a prometheus-operator ServiceMonitor object
+// based on the passed Service object.
+func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
+	labels := make(map[string]string)
+	for k, v := range s.ObjectMeta.Labels {
+		labels[k] = v
+	}
+
+	return &monitoringv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceMonitor",
+			APIVersion: "monitoring.coreos.com/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.ObjectMeta.Name,
+			Namespace: s.ObjectMeta.Namespace,
+			Labels:    labels,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port: s.Spec.Ports[0].Name,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This PR ensures that when the operator is deployed, all the proper objects are placed so prometheus can scrape the custom metrics.

-The operator creates a pagerduty-operator service to expose the metrics over on deploy
-The operator creates a pagerduty-operator servicemonitor to tell prometheus how to digest the metrics
-Removes the operator-sdk metrics service for now
-Includes a prometheus-k8s role for the pagerduty-operator namespace that has permissions to get, list and watch services, pods and endpoints.
-Includes a prometheus-k8s rolebinding to allow the prometheus-k8s serviceaccount from the openshift-monitoring namespace to use the aformentioned role.

When the operator and the role/rolebindings are deployed, the pagerduty-operator namespace must be given the following label to get everything working: openshift.io/cluster-monitoring="true"