### PR TITLE
Remove legacy finalizers if they exist

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,8 +15,9 @@
 package config
 
 const (
-	OperatorConfigMapName string = "pagerduty-config"
-	OperatorName          string = "pagerduty-operator"
-	OperatorNamespace     string = "pagerduty-operator"
-	OperatorFinalizer     string = "pd.managed.openshift.io/pagerduty"
+	OperatorConfigMapName   string = "pagerduty-config"
+	OperatorName            string = "pagerduty-operator"
+	OperatorNamespace       string = "pagerduty-operator"
+	OperatorFinalizer       string = "pd.managed.openshift.io/pagerduty"
+	OperatorFinalizerLegacy string = "pd.manage.openshift.io/pagerduty"
 )

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -101,6 +101,16 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{}, err
 	}
 
+	// This is a temp item to clean up old finalizers
+	if hivecontrollerutils.HasFinalizer(instance, config.OperatorFinalizerLegacy) {
+		hivecontrollerutils.DeleteFinalizer(instance, config.OperatorFinalizerLegacy)
+		err = r.client.Update(context.TODO(), instance)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{}, nil
+	}
+
 	if instance.DeletionTimestamp != nil {
 		if hivecontrollerutils.HasFinalizer(instance, config.OperatorFinalizer) {
 			return r.handleDelete(request, instance)

--- a/pkg/controller/clusterdeployment/clusterdeployment_created.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_created.go
@@ -51,14 +51,13 @@ func (r *ReconcileClusterDeployment) handleCreate(request reconcile.Request, ins
 
 	err := pdData.ParseClusterConfig(r.client, request.Namespace, request.Name)
 	if err != nil {
-		if err != nil {
-			var createErr error
-			pdIntegrationKey, createErr = pdData.CreateService()
-			if createErr != nil {
-				return reconcile.Result{}, createErr
-			}
+		var createErr error
+		pdIntegrationKey, createErr = pdData.CreateService()
+		if createErr != nil {
+			return reconcile.Result{}, createErr
 		}
 	}
+
 	pdIntegrationKey, err = pdData.GetIntegrationKey()
 	if err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
We the change of the finalizer name this PR will remove the old name if it exists then returns, will trigger a requeue since the CD changed