### PR TITLE
SREP-1352: Specify an IncidentUrgencyRule for new PD Services

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,4 +22,12 @@ const (
 	PagerDutyAPISecretKey   string = "PAGERDUTY_API_KEY"
 	OperatorFinalizer       string = "pd.managed.openshift.io/pagerduty"
 	OperatorFinalizerLegacy string = "pd.manage.openshift.io/pagerduty"
+
+	// PagerDutyUrgencyRule is the type of IncidentUrgencyRule for new incidents
+	// coming into the Service. This is for the creation of NEW SERVICES ONLY
+	// Supported values (by this operator) are:
+	// * high - Treat all incidents as high urgency
+	// * severity_based - Look to the severity on the PagerDuty Incident to map
+	//   the urgency. An unset incident severity is equivalent to critical.
+	PagerDutyUrgencyRule string = "severity_based"
 )

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -205,9 +205,9 @@ func (c *svcClient) CreateService(data *Data) (string, error) {
 		AcknowledgementTimeout: &data.acknowledgeTimeOut,
 		AlertCreation:          "create_alerts_and_incidents",
 		IncidentUrgencyRule: &pdApi.IncidentUrgencyRule{
-			Type: "constant",
+			Type:    "constant",
 			Urgency: config.PagerDutyUrgencyRule,
-		}
+		},
 	}
 
 	var newSvc *pdApi.Service

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openshift/pagerduty-operator/config"
+
 	pdApi "github.com/PagerDuty/go-pagerduty"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -202,6 +204,10 @@ func (c *svcClient) CreateService(data *Data) (string, error) {
 		AutoResolveTimeout:     &data.autoResolveTimeout,
 		AcknowledgementTimeout: &data.acknowledgeTimeOut,
 		AlertCreation:          "create_alerts_and_incidents",
+		IncidentUrgencyRule: &pdApi.IncidentUrgencyRule{
+			Type: "constant",
+			Urgency: config.PagerDutyUrgencyRule,
+		}
 	}
 
 	var newSvc *pdApi.Service


### PR DESCRIPTION
PagerDuty API has the ability to map incident severity to urgency. By
default PagerDuty treats all incidents (even low severity ones) as high
urgency incidents and thus will page, even for the most minor warnings.
This behaviour isn't desired (See SREP-1352). This change will have new
PagerDuty services (eg new clusters) created with a `severity_based`
Incident Urgency Rule to instruct PagerDuty to defer to the incident's
severity to inform urgency.

Signed-off-by: Lisa Seelye <lseelye@redhat.com>