### PR TITLE
Remove SyncSet if noalerts label is added

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ const (
 	PagerDutyAPISecretName string = "pagerduty-api-key"
 	PagerDutyAPISecretKey  string = "PAGERDUTY_API_KEY"
 	OperatorFinalizer      string = "pd.managed.openshift.io/pagerduty"
+	SyncSetPostfix         string = "-pd-sync"
 
 	// PagerDutyUrgencyRule is the type of IncidentUrgencyRule for new incidents
 	// coming into the Service. This is for the creation of NEW SERVICES ONLY

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -121,28 +121,25 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 	}
 
 	if instance.DeletionTimestamp != nil {
-		if utils.HasFinalizer(instance, config.OperatorFinalizer) {
-			return r.handleDelete(request, instance)
-		}
-		return reconcile.Result{}, nil
+		return r.handleDelete(request, instance)
 	}
 
 	// Just return if this is not a managed cluster
 	if val, ok := instance.Labels[config.ClusterDeploymentManagedLabel]; ok {
 		if val != "true" {
 			r.reqLogger.Info("Is not a managed cluster")
-			return reconcile.Result{}, nil
+			return r.handleDelete(request, instance)
 		}
 	} else {
 		// Managed tag is not present which implies it is not a managed cluster
 		r.reqLogger.Info("Is not a managed cluster")
-		return reconcile.Result{}, nil
+		return r.handleDelete(request, instance)
 	}
 
 	// Return if alerts are disabled on the cluster
 	if _, ok := instance.Labels[config.ClusterDeploymentNoalertsLabel]; ok {
 		r.reqLogger.Info("Managed cluster with Alerts disabled", "Namespace", request.Namespace, "Name", request.Name)
-		return reconcile.Result{}, nil
+		return r.handleDelete(request, instance)
 	}
 
 	ssName := fmt.Sprintf("%v-pd-sync", instance.Name)

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -326,6 +326,69 @@ func TestReconcileClusterDeployment(t *testing.T) {
 	}
 }
 
+func TestRemoveAlertsAfterCreate(t *testing.T) {
+	t.Run("Test Managed Cluster that later sets noalerts label", func(t *testing.T) {
+		// Arrange
+		mocks := setupDefaultMocks(t, []runtime.Object{
+			testClusterDeployment(),
+			testSecret(),
+			testPDConfigSecret(),
+			testPDConfigMap(), // <-- see comment below
+		})
+		// in order to test the delete, we need to crete the pd secret w/ a non-empty SERVICE_ID, which means CreateService won't be called
+
+		setupDMSMock :=
+			func(r *mockpd.MockClientMockRecorder) {
+				// create (without calling PD)
+				r.GetIntegrationKey(gomock.Any()).Return(testIntegrationID, nil).Times(1)
+
+				// delete
+				r.DeleteService(gomock.Any()).Return(nil).Times(1)
+			}
+
+		setupDMSMock(mocks.mockPDClient.EXPECT())
+
+		defer mocks.mockCtrl.Finish()
+
+		rcd := &ReconcileClusterDeployment{
+			client:   mocks.fakeKubeClient,
+			scheme:   scheme.Scheme,
+			pdclient: mocks.mockPDClient,
+		}
+
+		// Act (create)
+		_, err := rcd.Reconcile(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      testClusterName,
+				Namespace: testNamespace,
+			},
+		})
+
+		// UPDATE (noalerts)
+		// can't set to empty string, it won't update.. value does not matter
+		clusterDeployment := &hivev1alpha1.ClusterDeployment{}
+		err = mocks.fakeKubeClient.Get(context.TODO(), types.NamespacedName{Namespace: testNamespace, Name: testClusterName}, clusterDeployment)
+		clusterDeployment.Labels[config.ClusterDeploymentNoalertsLabel] = "X"
+		err = mocks.fakeKubeClient.Update(context.TODO(), clusterDeployment)
+
+		err = mocks.fakeKubeClient.Get(context.TODO(), types.NamespacedName{Namespace: testNamespace, Name: testClusterName}, clusterDeployment)
+
+		println(clusterDeployment.Labels[config.ClusterDeploymentNoalertsLabel])
+
+		// Act (delete)
+		_, err = rcd.Reconcile(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      testClusterName,
+				Namespace: testNamespace,
+			},
+		})
+
+		// Assert
+		assert.NoError(t, err, "Unexpected Error")
+		assert.True(t, verifyNoSyncSetExists(mocks.fakeKubeClient, &SyncSetEntry{}))
+	})
+}
+
 // verifySyncSetExists verifies that a SyncSet exists that matches the supplied expected SyncSetEntry.
 func verifySyncSetExists(c client.Client, expected *SyncSetEntry) bool {
 	ss := hivev1alpha1.SyncSet{}

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -373,8 +373,6 @@ func TestRemoveAlertsAfterCreate(t *testing.T) {
 
 		err = mocks.fakeKubeClient.Get(context.TODO(), types.NamespacedName{Namespace: testNamespace, Name: testClusterName}, clusterDeployment)
 
-		println(clusterDeployment.Labels[config.ClusterDeploymentNoalertsLabel])
-
 		// Act (delete)
 		_, err = rcd.Reconcile(reconcile.Request{
 			NamespacedName: types.NamespacedName{

--- a/pkg/controller/clusterdeployment/clusterdeployment_deleted.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_deleted.go
@@ -61,7 +61,6 @@ func (r *ReconcileClusterDeployment) handleDelete(request reconcile.Request, ins
 		err = r.client.Delete(context.TODO(), syncset)
 		if err != nil {
 			r.reqLogger.Error(err, "Error deleting SyncSet", "Namespace", request.Namespace, "Name", ssName)
-			return reconcile.Result{}, err
 		}
 	}
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_deleted.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_deleted.go
@@ -30,7 +30,6 @@ func (r *ReconcileClusterDeployment) handleDelete(request reconcile.Request, ins
 	if !utils.HasFinalizer(instance, config.OperatorFinalizer) {
 		return reconcile.Result{}, nil
 	}
-	println("handleDelete")
 
 	ClusterID := instance.Spec.ClusterName
 
@@ -43,15 +42,10 @@ func (r *ReconcileClusterDeployment) handleDelete(request reconcile.Request, ins
 		return reconcile.Result{}, err
 	}
 
-	println("1")
-
 	err = pdData.ParseClusterConfig(r.client, request.Namespace, request.Name)
 	if err != nil {
-		println("1 err: " + err.Error())
 		return reconcile.Result{}, err
 	}
-
-	println("2")
 
 	err = r.pdclient.DeleteService(pdData)
 	if err != nil {
@@ -60,7 +54,6 @@ func (r *ReconcileClusterDeployment) handleDelete(request reconcile.Request, ins
 
 	// find the PD syncset and delete it
 	ssName := request.Name + config.SyncSetPostfix
-	println(ssName)
 	r.reqLogger.Info("Deleting PD SyncSet", "Namespace", request.Namespace, "Name", request.Name)
 	syncset := &hivev1.SyncSet{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: request.Namespace, Name: ssName}, syncset)

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -36,8 +36,6 @@ import (
 
 var log = logf.Log.WithName("controller_syncset")
 
-const syncsetPostfix string = "-pd-sync"
-
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
 * business logic.  Delete these comments after modifying this file.*
@@ -135,10 +133,10 @@ func (r *ReconcileSyncSet) Reconcile(request reconcile.Request) (reconcile.Resul
 	r.reqLogger.Info("Reconciling SyncSet")
 
 	// Wasn't a pagerduty
-	if len(request.Name) < len(syncsetPostfix) {
+	if len(request.Name) < len(config.SyncSetPostfix) {
 		return reconcile.Result{}, nil
 	}
-	if request.Name[len(request.Name)-len(syncsetPostfix):len(request.Name)] != syncsetPostfix {
+	if request.Name[len(request.Name)-len(config.SyncSetPostfix):len(request.Name)] != config.SyncSetPostfix {
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-1572

Added SyncSet deletion to handleDelete and reference from a few more places.  It checks the finalizer first and bails if there is no finalizer so should be lightweight.