### PR TITLE
Ignore missing config on delete

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -257,6 +257,17 @@ func TestReconcileClusterDeployment(t *testing.T) {
 			},
 		},
 		{
+			name: "Test Deleting with missing ConfigMap",
+			localObjects: []runtime.Object{
+				deletedClusterDeployment(),
+				testPDConfigSecret(),
+			},
+			expectedSyncSets: &SyncSetEntry{},
+			verifySyncSets:   verifyNoSyncSetExists,
+			setupPDMock: func(r *mockpd.MockClientMockRecorder) {
+			},
+		},
+		{
 			name: "Test Creating (unmanaged with label)",
 			localObjects: []runtime.Object{
 				unmanagedClusterDeployment(),


### PR DESCRIPTION
Can't do anything if the config isn't there, it's not a recoverable state.

https://jira.coreos.com/browse/SREP-2250