### PR TITLE
Fix yaml validation in PR check

### DIFF
--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -10,7 +10,7 @@ YAML_DIRS=( "${CURRENT_DIR}/../deploy/crds" "${CURRENT_DIR}/../manifests" )
 for DIR in $YAML_DIRS 
 do 
 	if [[ -d $DIR ]]; then
-		python "$CURRENT_DIR"/validate_yaml.py $CRD_DIR
+		python "$CURRENT_DIR"/validate_yaml.py $DIR
 
 		if [ "$?" != "0" ]; then
 		    exit 1


### PR DESCRIPTION
We haven't (and dont' in master yet) have any yaml to validate so never caught this.  With upcoming work to introduce configuration to the operator the PR check is failing because of this.