### PR TITLE
Fix YAML validation

### DIFF
--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -5,22 +5,16 @@
 set -exv
 
 CURRENT_DIR=$(dirname "$0")
-YAML_DIRS=( "${CURRENT_DIR}/../deploy/crds" "${CURRENT_DIR}/../manifests" )
+REPO_ROOT=$(git rev-parse --show-toplevel)
+YAML_FILES=$(git ls-tree --full-tree -r --name-only HEAD | egrep '\.ya?ml$')
 
-for DIR in $YAML_DIRS 
+for YAML_FILE in $YAML_FILES
 do 
-	if [[ -d $DIR ]]; then
-		python "$CURRENT_DIR"/validate_yaml.py $DIR
-
-		if [ "$?" != "0" ]; then
-		    exit 1
-		fi
-
-	else
-		echo "WARNING: No yaml for validation in directiory $DIR"
-	fi
+	# `-e` will fail the script if one of these is bad
+	python "$CURRENT_DIR"/validate_yaml.py $REPO_ROOT/$YAML_FILE
 done 
 
+# TODO: ??
 exit 0
 
 BASE_IMG="pagerduty-operator"

--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -14,9 +14,6 @@ do
 	python "$CURRENT_DIR"/validate_yaml.py $REPO_ROOT/$YAML_FILE
 done 
 
-# TODO: ??
-exit 0
-
 BASE_IMG="pagerduty-operator"
 IMG="${BASE_IMG}:latest"
 

--- a/hack/validate_yaml.py
+++ b/hack/validate_yaml.py
@@ -34,7 +34,8 @@ for file_path in files:
     with open(file_path, 'r') as f:
         data = f.read()
     try:
-        yaml.safe_load_all(data)
+        for y in yaml.safe_load_all(data):
+            pass
     except Exception as e:
         print(e)
         error = True


### PR DESCRIPTION
- `hack/validate_yaml.py` was a no-op when run under py3 because `yaml.safe_load_all()` produces a generator, and doesn't actually parse the YAML until you iterate on it. Fix.
- Previously `app_sre_pr_check.sh` was assembling YAML directories in an
array, but only "looping" over the first one. Now we intelligently look for all YAML files (.yml or
.yaml suffix) under source control in the current repo and run validation on them one by one.