### PR TITLE
Add support for new 'ext' noalerts label.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This operator runs on [Hive](https://github.com/openshift/hive) and watches for 
 ## How the PagerDuty Operator works
 
 * The PagerDutyIntegration controller watches for changes to PagerDutyIntegration CRs, and also for changes to appropriately labeled ClusterDeployment CRs (and ConfigMap/Secret/SyncSet resources owned by such a ClusterDeployment).
-* For each PagerDutyIntegration CR, it will get a list of matching ClusterDeployments that have the `spec.installed` field set to true and don't have the `api.openshift.com/noalerts` label set.
+* For each PagerDutyIntegration CR, it will get a list of matching ClusterDeployments that have the `spec.installed` field set to true and don't have the `ext-managed.openshift.io/noalerts` label set.
+  * The `ext-managed.openshift.io/noalerts` label is used to disable alerts from the provisioned cluster. This label is typically used on test clusters that do not require immediate attention as a result of critical issues or outages. Therefore, PagerDuty does not continue its actions if it finds this label in the new cluster's `ClusterDeployment`.
 * For each of these ClusterDeployments, PagerDuty creates a secret which contains the integration key required to communicate with PagerDuty Web application.
 * The PagerDuty operator then creates [syncset](https://github.com/openshift/hive/blob/master/config/crds/hive_v1_syncset.yaml) with the relevant information for hive to send the PagerDuty secret to the newly provisioned cluster .
 * This syncset is used by hive to deploy the pagerduty secret to the provisioned cluster so that the relevant SRE team get notified of alerts on the cluster.

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,9 @@ const (
 	// if the cluster is OSD (managed) or not
 	ClusterDeploymentManagedLabel string = "api.openshift.com/managed"
 	// ClusterDeploymentNoalertsLabel is the label the clusterdeployment will have if the cluster should not send alerts
-	ClusterDeploymentNoalertsLabel string = "api.openshift.com/noalerts"
+	ClusterDeploymentNoalertsLabel string = "ext-managed.openshift.io/noalerts"
+	// ClusterDeploymentNoalertsLabelOld is the OLD label used and will be remoed as a part of https://issues.redhat.com/browse/OSD-4059
+	ClusterDeploymentNoalertsLabelOld string = "api.openshift.com/noalerts"
 )
 
 // Name is used to generate the name of secondary resources (SyncSets,


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-4059

A future phase will remove the old label.  Tracked as a task in the above story.