### PR TITLE
Fix data type for resolveTimeout and acknowledgeTimeout in template

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -54,8 +54,8 @@ objects:
     name: osd
     namespace: pagerduty-operator
   spec:
-    acknowledgeTimeout: ${ACKNOWLEDGE_TIMEOUT}
-    resolveTimeout: ${RESOLVE_TIMEOUT}
+    acknowledgeTimeout: ${{ACKNOWLEDGE_TIMEOUT}}
+    resolveTimeout: ${{RESOLVE_TIMEOUT}}
     escalationPolicy: ${ESCALATION_POLICY}
     servicePrefix: ${SERVICE_PREFIX}
     pagerdutyApiKeySecretRef:


### PR DESCRIPTION
They were being treated as strings by `oc process` and they need to be integers.
Ideally PR check would catch this, not sure how to validate the CR w/o a live cluster though so will open separate PR if/when I can for that.