### PR TITLE
Implement new metrics for kubeclient and reconcile duration - OSD-4567 + OSD-4569

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,6 @@ tags
 ### VisualStudioCode ###
 .vscode/*
 .history
+### Eclipse ###
+.project
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -106,6 +106,8 @@ func start() error {
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace: "",
+		// Disable controller-runtime metrics serving
+		MetricsBindAddress: "0",
 	})
 	if err != nil {
 		log.Error(err, "")

--- a/pkg/localmetrics/localmetrics_test.go
+++ b/pkg/localmetrics/localmetrics_test.go
@@ -1,0 +1,89 @@
+package localmetrics
+
+import (
+	neturl "net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathParse(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "core non-namespaced kind",
+			path:     "/api/v1/pods",
+			expected: "core/v1/pods",
+		},
+		{
+			name:     "core non-namespaced named resource",
+			path:     "/api/v1/nodes/nodename",
+			expected: "core/v1/nodes/{NAME}",
+		},
+		{
+			name:     "core namespaced named resource",
+			path:     "/api/v1/namespaces/pagerduty-operator/configmaps/foo-bar-baz",
+			expected: "core/v1/namespaces/{NAMESPACE}/configmaps/{NAME}",
+		},
+		{
+			name:     "core namespaced named resource with sub-resource",
+			path:     "/api/v1/namespaces/pagerduty-operator/secret/foo-bar-baz/status",
+			expected: "core/v1/namespaces/{NAMESPACE}/secret/{NAME}/status",
+		},
+		{
+			name:     "extension non-namespaced kind",
+			path:     "/apis/batch/v1/jobs",
+			expected: "batch/v1/jobs",
+		},
+		{
+			name:     "extension namespaced kind",
+			path:     "/apis/batch/v1/namespaces/pagerduty-operator/jobs",
+			expected: "batch/v1/namespaces/{NAMESPACE}/jobs",
+		},
+		{
+			name:     "extension namespaced named resource",
+			path:     "/apis/batch/v1/namespaces/pagerduty-operator/jobs/foo-bar-baz",
+			expected: "batch/v1/namespaces/{NAMESPACE}/jobs/{NAME}",
+		},
+		{
+			name:     "extension namespaced named resource with sub-resource",
+			path:     "/apis/pd.managed.openshift.io/v1alpha1/namespaces/pagerduty-operator/accountpool/foo-bar-baz/status",
+			expected: "pd.managed.openshift.io/v1alpha1/namespaces/{NAMESPACE}/accountpool/{NAME}/status",
+		},
+		{
+			name:     "core root (discovery)",
+			path:     "/api",
+			expected: "core",
+		},
+		{
+			name:     "core version (discovery)",
+			path:     "/api/v1",
+			expected: "core/v1",
+		},
+		{
+			name:     "extension discovery",
+			path:     "/apis/pagerduty.managed.openshift.io/v1",
+			expected: "pagerduty.managed.openshift.io/v1",
+		},
+		{
+			name:     "unknown root",
+			path:     "/weird/path/to/resource",
+			expected: "{OTHER}",
+		},
+		{
+			name:     "empty to make Split fail",
+			path:     "",
+			expected: "{OTHER}",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := resourceFrom(&neturl.URL{Path: test.path})
+			assert.Equal(t, test.expected, result)
+		})
+	}
+
+}

--- a/pkg/utils/clientwrapper.go
+++ b/pkg/utils/clientwrapper.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift/pagerduty-operator/pkg/localmetrics"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("clientwrapper")
+
+// NewClientWithMetricsOrDie creates a new controller-runtime client with a wrapper which increments
+// metrics for requests by controller name, HTTP method, URL path, and HTTP status. The client will
+// re-use the manager's cache. This should be used in all controllers.
+func NewClientWithMetricsOrDie(log logr.Logger, mgr manager.Manager, controller string) client.Client {
+	// Copy the rest.Config as we want our round trippers to be controller-specific.
+	cfg := rest.CopyConfig(mgr.GetConfig())
+	AddControllerMetricsTransportWrapper(cfg, controller)
+
+	options := client.Options{
+		Scheme: mgr.GetScheme(),
+		Mapper: mgr.GetRESTMapper(),
+	}
+	c, err := client.New(cfg, options)
+	if err != nil {
+		log.Error(err, "Unable to initialize metrics-wrapped client")
+		os.Exit(1)
+	}
+
+	return &client.DelegatingClient{
+		Reader: &client.DelegatingReader{
+			CacheReader:  mgr.GetCache(),
+			ClientReader: c,
+		},
+		Writer:       c,
+		StatusClient: c,
+	}
+}
+
+// AddControllerMetricsTransportWrapper adds a transport wrapper to the given rest config which
+// exposes metrics based on the requests being made.
+func AddControllerMetricsTransportWrapper(cfg *rest.Config, controllerName string) {
+	// If the restConfig already has a transport wrapper, wrap it.
+	if cfg.WrapTransport != nil {
+		origFunc := cfg.WrapTransport
+		cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+			return &ControllerMetricsTripper{
+				RoundTripper: origFunc(rt),
+				Controller:   controllerName,
+			}
+		}
+	}
+
+	cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		return &ControllerMetricsTripper{
+			RoundTripper: rt,
+			Controller:   controllerName,
+		}
+	}
+}
+
+// ControllerMetricsTripper is a RoundTripper implementation which tracks our metrics for client requests.
+type ControllerMetricsTripper struct {
+	http.RoundTripper
+	Controller string
+}
+
+// RoundTrip implements the http RoundTripper interface. We simply call the wrapped RoundTripper
+// and register the call with our apiCallCount metric.
+func (cmt *ControllerMetricsTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	// Call the nested RoundTripper.
+	resp, err := cmt.RoundTripper.RoundTrip(req)
+
+	// Count this call, if it worked (where "worked" includes HTTP errors).
+	if err == nil {
+		localmetrics.AddAPICall(cmt.Controller, req, resp, time.Since(start).Seconds())
+	}
+
+	return resp, err
+}


### PR DESCRIPTION
1) Register 2 new metrics
* `pagerduty_operator_api_request_duration_seconds` timing the kubeclient calls with controller, method, resource and status dimensions 
* `pagerduty_operator_reconcile_duration_seconds` timing the reconcile loop with controller label

2) Instrument the controller-runtime Client to include the metric calculation for each request

3) Standardise the resource from the HTTP request by removing reference to object names to allow proper aggregation 

4) Disable controller-runtime metrics serving as conflicting with the custom-metrics and unused