### PR TITLE
Implement new metrics for PD API calls

### DIFF
--- a/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
+++ b/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
@@ -146,7 +146,7 @@ type ReconcilePagerDutyIntegration struct {
 	client    client.Client
 	scheme    *runtime.Scheme
 	reqLogger logr.Logger
-	pdclient  func(APIKey string) pd.Client
+	pdclient  func(APIKey string, controllerName string) pd.Client
 }
 
 // Reconcile reads that state of the cluster for a PagerDutyIntegration object and makes changes based on the state read
@@ -197,7 +197,7 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 		return r.requeueAfter(10 * time.Minute)
 	}
 	localmetrics.UpdateMetricPagerDutyIntegrationSecretLoaded(1, pdi.Name)
-	pdClient := r.pdclient(pdApiKey)
+	pdClient := r.pdclient(pdApiKey, controllerName)
 
 	if pdi.DeletionTimestamp != nil {
 		if utils.HasFinalizer(pdi, config.OperatorFinalizer) {

--- a/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller_test.go
+++ b/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller_test.go
@@ -506,7 +506,7 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 			rpdi := &ReconcilePagerDutyIntegration{
 				client:   mocks.fakeKubeClient,
 				scheme:   scheme.Scheme,
-				pdclient: func(s string) pd.Client { return mocks.mockPDClient },
+				pdclient: func(s1 string, s2 string) pd.Client { return mocks.mockPDClient },
 			}
 
 			// Act [2x as first exits early after setting finalizer]
@@ -560,7 +560,7 @@ func TestRemoveAlertsAfterCreate(t *testing.T) {
 		rpdi := &ReconcilePagerDutyIntegration{
 			client:   mocks.fakeKubeClient,
 			scheme:   scheme.Scheme,
-			pdclient: func(s string) pd.Client { return mocks.mockPDClient },
+			pdclient: func(s1 string, s2 string) pd.Client { return mocks.mockPDClient },
 		}
 
 		// Act (create) [2x as first exits early after setting finalizer]
@@ -640,7 +640,7 @@ func TestDeleteSecret(t *testing.T) {
 		rpdi := &ReconcilePagerDutyIntegration{
 			client:   mocks.fakeKubeClient,
 			scheme:   scheme.Scheme,
-			pdclient: func(s string) pd.Client { return mocks.mockPDClient },
+			pdclient: func(s1 string, s2 string) pd.Client { return mocks.mockPDClient },
 		}
 
 		// Act (create) [2x as first exits early after setting finalizer]

--- a/pkg/localmetrics/localmetrics_test.go
+++ b/pkg/localmetrics/localmetrics_test.go
@@ -10,78 +10,116 @@ import (
 func TestPathParse(t *testing.T) {
 	tests := []struct {
 		name     string
+		host     string
 		path     string
 		expected string
 	}{
 		{
 			name:     "core non-namespaced kind",
+			host:     "172.30.0.1:443",
 			path:     "/api/v1/pods",
 			expected: "core/v1/pods",
 		},
 		{
 			name:     "core non-namespaced named resource",
+			host:     "172.30.0.1:443",
 			path:     "/api/v1/nodes/nodename",
 			expected: "core/v1/nodes/{NAME}",
 		},
 		{
 			name:     "core namespaced named resource",
+			host:     "172.30.0.1:443",
 			path:     "/api/v1/namespaces/pagerduty-operator/configmaps/foo-bar-baz",
 			expected: "core/v1/namespaces/{NAMESPACE}/configmaps/{NAME}",
 		},
 		{
 			name:     "core namespaced named resource with sub-resource",
+			host:     "172.30.0.1:443",
 			path:     "/api/v1/namespaces/pagerduty-operator/secret/foo-bar-baz/status",
 			expected: "core/v1/namespaces/{NAMESPACE}/secret/{NAME}/status",
 		},
 		{
 			name:     "extension non-namespaced kind",
+			host:     "172.30.0.1:443",
 			path:     "/apis/batch/v1/jobs",
 			expected: "batch/v1/jobs",
 		},
 		{
 			name:     "extension namespaced kind",
+			host:     "172.30.0.1:443",
 			path:     "/apis/batch/v1/namespaces/pagerduty-operator/jobs",
 			expected: "batch/v1/namespaces/{NAMESPACE}/jobs",
 		},
 		{
 			name:     "extension namespaced named resource",
+			host:     "172.30.0.1:443",
 			path:     "/apis/batch/v1/namespaces/pagerduty-operator/jobs/foo-bar-baz",
 			expected: "batch/v1/namespaces/{NAMESPACE}/jobs/{NAME}",
 		},
 		{
 			name:     "extension namespaced named resource with sub-resource",
+			host:     "172.30.0.1:443",
 			path:     "/apis/pd.managed.openshift.io/v1alpha1/namespaces/pagerduty-operator/accountpool/foo-bar-baz/status",
 			expected: "pd.managed.openshift.io/v1alpha1/namespaces/{NAMESPACE}/accountpool/{NAME}/status",
 		},
 		{
 			name:     "core root (discovery)",
+			host:     "172.30.0.1:443",
 			path:     "/api",
 			expected: "core",
 		},
 		{
 			name:     "core version (discovery)",
+			host:     "172.30.0.1:443",
 			path:     "/api/v1",
 			expected: "core/v1",
 		},
 		{
 			name:     "extension discovery",
+			host:     "172.30.0.1:443",
 			path:     "/apis/pagerduty.managed.openshift.io/v1",
 			expected: "pagerduty.managed.openshift.io/v1",
 		},
 		{
 			name:     "unknown root",
+			host:     "172.30.0.1:443",
 			path:     "/weird/path/to/resource",
 			expected: "{OTHER}",
 		},
 		{
 			name:     "empty to make Split fail",
+			host:     "172.30.0.1:443",
 			path:     "",
 			expected: "{OTHER}",
+		},
+		{
+			name:     "access to escalation policies",
+			host:     "pagerduty.com",
+			path:     "/escalation_policies/PPP12345XXX",
+			expected: "pagerduty.com/escalation_policies/{UID}",
+		},
+		{
+			name:     "retrieve service",
+			host:     "pagerduty.com",
+			path:     "/services/PPP12345XXX",
+			expected: "pagerduty.com/services/{UID}",
+		},
+		{
+			name:     "retrieve integration",
+			host:     "pagerduty.com",
+			path:     "/services/PPP12345XXX/integrations/PPP12345XXX",
+			expected: "pagerduty.com/services/{UID}/integrations/{UID}",
+		},
+		{
+			name:     "ignore further subresources",
+			host:     "pagerduty.com",
+			path:     "/services/PPP12345XXX/integrations/PPP12345XXX/subresource/PPP12345XXX",
+			expected: "pagerduty.com/services/{UID}/integrations/{UID}",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := resourceFrom(&neturl.URL{Path: test.path})
+			result := resourceFrom(&neturl.URL{Host: test.host, Path: test.path})
 			assert.Equal(t, test.expected, result)
 		})
 	}


### PR DESCRIPTION
1) Adding a custom HTTPClient in order to measure API Calls duration and push to prometheus
2) Updating the `resourceFrom` method to manage pagerduty API calls
