### PR TITLE
OSD-5077 Lock registry image in 4.5

### DIFF
--- a/build/Dockerfile.catalog_registry
+++ b/build/Dockerfile.catalog_registry
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-operator-registry:latest
+FROM quay.io/openshift/origin-operator-registry:4.5
 
 ARG SRC_BUNDLES
 


### PR DESCRIPTION
### What type of PR is this? 
_(bug/feature/cleanup/docs/design/test/chore/refactor..)_
Bug
### What this PR does / why we need it:
Openshift-registry introduced a breaking change in 4.6 in their docker image, locking img tag in 4.5

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
OSD-5077
