### PR TITLE
Use correct capitalization for selector operator

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -66,7 +66,7 @@ objects:
     clusterDeploymentSelector:
       matchExpressions:
       - key: api.openshift.com/managed
-        operator: in
+        operator: In
         values: ["true"]
       - key: api.openshift.com/legal-entity-id
         operator: NotIn
@@ -90,7 +90,7 @@ objects:
     clusterDeploymentSelector:
       matchExpressions:
       - key: api.openshift.com/managed
-        operator: in
+        operator: In
         values: ["true"]
       - key: api.openshift.com/legal-entity-id
         operator: In


### PR DESCRIPTION
Fix the following error:
```
"request":"pagerduty-operator/osd-silent","error":"\"in\" is not a valid pod selector operator"
```