### PR TITLE
Change silent service prefix to single curly brackets

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -85,7 +85,7 @@ objects:
     acknowledgeTimeout: ${{ACKNOWLEDGE_TIMEOUT}}
     resolveTimeout: ${{RESOLVE_TIMEOUT}}
     escalationPolicy: ${{ESCALATION_POLICY_SILENT}}
-    servicePrefix: ${{SERVICE_PREFIX}}_silent
+    servicePrefix: ${SERVICE_PREFIX}_silent
     pagerdutyApiKeySecretRef:
       name: pagerduty-api-key
       namespace: pagerduty-operator


### PR DESCRIPTION
Apparently when the template processes through CI, it only likes single curly brackets when it is part of a string