### PR TITLE
Update PDI to not alert for 'nightly' channel-group clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -73,6 +73,9 @@ objects:
       - key: api.openshift.com/legal-entity-id
         operator: NotIn
         values: ${{SILENT_ALERT_LEGALENTITY_IDS}}
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values: ["nightly"]
     targetSecretRef:
       name: pd-secret
       namespace: openshift-monitoring


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-5375

Note this is ahead of having the label set at all but will position us to use it immediately after available: https://issues.redhat.com/browse/SDA-3021