### PR TITLE
Remove code to handle noalerts labels, move to PagerDutyIntegration instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ This operator runs on [Hive](https://github.com/openshift/hive) and watches for 
 ## How the PagerDuty Operator works
 
 * The PagerDutyIntegration controller watches for changes to PagerDutyIntegration CRs, and also for changes to appropriately labeled ClusterDeployment CRs (and ConfigMap/Secret/SyncSet resources owned by such a ClusterDeployment).
-* For each PagerDutyIntegration CR, it will get a list of matching ClusterDeployments that have the `spec.installed` field set to true and don't have the `ext-managed.openshift.io/noalerts` label set.
-  * The `ext-managed.openshift.io/noalerts` label is used to disable alerts from the provisioned cluster. This label is typically used on test clusters that do not require immediate attention as a result of critical issues or outages. Therefore, PagerDuty does not continue its actions if it finds this label in the new cluster's `ClusterDeployment`.
+* For each PagerDutyIntegration CR, it will get a list of matching ClusterDeployments that have the `spec.installed` field set to true.
 * For each of these ClusterDeployments, PagerDuty creates a secret which contains the integration key required to communicate with PagerDuty Web application.
 * The PagerDuty operator then creates [syncset](https://github.com/openshift/hive/blob/master/config/crds/hive_v1_syncset.yaml) with the relevant information for hive to send the PagerDuty secret to the newly provisioned cluster .
 * This syncset is used by hive to deploy the pagerduty secret to the provisioned cluster so that the relevant SRE team get notified of alerts on the cluster.

--- a/config/config.go
+++ b/config/config.go
@@ -36,10 +36,6 @@ const (
 	// ClusterDeploymentManagedLabel is the label the clusterdeployment will have that determines
 	// if the cluster is OSD (managed) or not
 	ClusterDeploymentManagedLabel string = "api.openshift.com/managed"
-	// ClusterDeploymentNoalertsLabel is the label the clusterdeployment will have if the cluster should not send alerts
-	ClusterDeploymentNoalertsLabel string = "ext-managed.openshift.io/noalerts"
-	// ClusterDeploymentNoalertsLabelOld is the OLD label used and will be remoed as a part of https://issues.redhat.com/browse/OSD-4059
-	ClusterDeploymentNoalertsLabelOld string = "api.openshift.com/noalerts"
 )
 
 // Name is used to generate the name of secondary resources (SyncSets,

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -67,12 +67,23 @@ objects:
       namespace: pagerduty-operator
     clusterDeploymentSelector:
       matchExpressions:
+      # only create PD service for managed (OSD) clusters
       - key: api.openshift.com/managed
         operator: In
         values: ["true"]
+      # ignore CD w/ "legacy" noalerts label
+      - key: api.openshift.com/noalerts
+        operator: NotIn
+        values: ["true"]
+      # ignore CD w/ ext noalerts label
+      - key: ext-managed.openshift.io/noalerts
+        operator: NotIn
+        values: ["true"]
+      # ignore CD for specific organizations
       - key: api.openshift.com/legal-entity-id
         operator: NotIn
         values: ${{SILENT_ALERT_LEGALENTITY_IDS}}
+      # ignore CD for any "nightly" clusters
       - key: api.openshift.com/channel-group
         operator: NotIn
         values: ["nightly"]
@@ -94,9 +105,19 @@ objects:
       namespace: pagerduty-operator
     clusterDeploymentSelector:
       matchExpressions:
+      # only create PD service for managed (OSD) clusters
       - key: api.openshift.com/managed
         operator: In
         values: ["true"]
+      # ignore CD w/ "legacy" noalerts label
+      - key: api.openshift.com/noalerts
+        operator: NotIn
+        values: ["true"]
+      # ignore CD w/ ext noalerts label
+      - key: ext-managed.openshift.io/noalerts
+        operator: NotIn
+        values: ["true"]
+      # for the "silent" PDI, create when CD in specific organizations we ignore in the "osd" (regular) PDI
       - key: api.openshift.com/legal-entity-id
         operator: In
         values: ${{SILENT_ALERT_LEGALENTITY_IDS}}

--- a/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
+++ b/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
@@ -228,7 +228,7 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 	}
 
 	for _, cd := range matchingClusterDeployments.Items {
-		if cd.DeletionTimestamp != nil || cd.Labels[config.ClusterDeploymentNoalertsLabel] == "true" {
+		if cd.DeletionTimestamp != nil {
 			err := r.handleDelete(pdClient, pdi, &cd)
 			if err != nil {
 				return r.requeueOnErr(err)


### PR DESCRIPTION
Realized this morning we could strip all of this logic out and rely on the clusterDelpoymentSelector for noalerts capabilities.