### PR TITLE
Update yq syntax and fix saas file location

### DIFF
--- a/functions.mk
+++ b/functions.mk
@@ -7,6 +7,7 @@
 # 6 - saasherder config path (absolute within repo, eg /name/hive.yaml)
 # 7 - relative path to bundle generator python script (eg ./build/generate-operator-bundle.py)
 # 8 - Catalog registry quay.io organization name (eg openshift-sre)
+# 9 - Operator name
 # Uses these variables (from project.mk or standard.mk):
 # Operator image
 # Git hash
@@ -18,7 +19,7 @@ define create_push_catalog_image
 	mkdir -p bundles-$(1)/$(OPERATOR_NAME) ;\
 	removed_versions="" ;\
 	if [[ "$$(echo $(4) | tr [:upper:] [:lower:])" == "true" ]]; then \
-		deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq -r '.services[]|select(.name="pagerduty-operator").hash') ;\
+		deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq yq r - 'resourceTemplates[*].targets(namespace.$ref==/services/osd-operators/namespaces/hivep01ue1/$(9).yml).ref') ;\
 		delete=false ;\
 		for bundle_path in $$(find bundles-$(1) -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V); do \
 			if [[ "$${delete}" == false ]]; then \

--- a/standard.mk
+++ b/standard.mk
@@ -70,8 +70,8 @@ skopeo-push: build
 
 .PHONY: build-catalog-image
 build-catalog-image:
-	$(call create_push_catalog_image,staging,service/saas-pagerduty-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,false,service/saas-osd-operators,$(OPERATOR_NAME)-services/$(OPERATOR_NAME).yaml,hack/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION))
-	$(call create_push_catalog_image,production,service/saas-pagerduty-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,true,service/saas-osd-operators,$(OPERATOR_NAME)-services/$(OPERATOR_NAME).yaml,hack/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION))
+	$(call create_push_catalog_image,staging,service/saas-pagerduty-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,false,service/app-interface,data/services/osd-operators/cicd/saas/saas-$(OPERATOR_NAME).yaml,hack/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION),$(OPERATOR_NAME))
+	$(call create_push_catalog_image,production,service/saas-pagerduty-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,true,service/app-interface,data/services/osd-operators/cicd/saas/saas-$(OPERATOR_NAME).yaml,hack/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION),$(OPERATOR_NAME))
 
 .PHONY: gocheck
 gocheck: ## Lint code


### PR DESCRIPTION
The image used for yq was change to be the golang version which has a completely different syntax to the original python version. The entry point for the container is also not correct hence needing the extra `yq`. 

The path to discover what version of the operator promoted to production has changed in app-interface, this has been updated.