### PR TITLE
Fix to delete PD service for CD that no longer matches PDI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ This operator runs on [Hive](https://github.com/openshift/hive) and watches for 
 ## How the PagerDuty Operator works
 
 * The PagerDutyIntegration controller watches for changes to PagerDutyIntegration CRs, and also for changes to appropriately labeled ClusterDeployment CRs (and ConfigMap/Secret/SyncSet resources owned by such a ClusterDeployment).
-* For each PagerDutyIntegration CR, it will get a list of matching ClusterDeployments that have the `spec.installed` field set to true and don't have the `ext-managed.openshift.io/noalerts` label set.
-  * The `ext-managed.openshift.io/noalerts` label is used to disable alerts from the provisioned cluster. This label is typically used on test clusters that do not require immediate attention as a result of critical issues or outages. Therefore, PagerDuty does not continue its actions if it finds this label in the new cluster's `ClusterDeployment`.
+* For each PagerDutyIntegration CR, it will get a list of matching ClusterDeployments that have the `spec.installed` field set to true.
 * For each of these ClusterDeployments, PagerDuty creates a secret which contains the integration key required to communicate with PagerDuty Web application.
 * The PagerDuty operator then creates [syncset](https://github.com/openshift/hive/blob/master/config/crds/hive_v1_syncset.yaml) with the relevant information for hive to send the PagerDuty secret to the newly provisioned cluster .
 * This syncset is used by hive to deploy the pagerduty secret to the provisioned cluster so that the relevant SRE team get notified of alerts on the cluster.

--- a/config/config.go
+++ b/config/config.go
@@ -21,9 +21,14 @@ const (
 	PagerDutyAPISecretName string = "pagerduty-api-key"
 	PagerDutyAPISecretKey  string = "PAGERDUTY_API_KEY"
 	PagerDutySecretKey     string = "PAGERDUTY_KEY"
-	OperatorFinalizer      string = "pd.managed.openshift.io/pagerduty"
-	SecretSuffix           string = "-pd-secret"
-	ConfigMapSuffix        string = "-pd-config"
+	// PagerDutyFinalizerPrefix prefix used for finalizers on resources other than PDI
+	PagerDutyFinalizerPrefix string = "pd.managed.openshift.io/"
+	// PagerDutyIntegrationFinalizer name of finalizer used for PDI
+	PagerDutyIntegrationFinalizer string = "pd.managed.openshift.io/pagerduty"
+	// LegacyPagerDutyFinalizer name of legacy finalizer, always to be deleted
+	LegacyPagerDutyFinalizer string = "pd.managed.openshift.io/pagerduty"
+	SecretSuffix             string = "-pd-secret"
+	ConfigMapSuffix          string = "-pd-config"
 
 	// PagerDutyUrgencyRule is the type of IncidentUrgencyRule for new incidents
 	// coming into the Service. This is for the creation of NEW SERVICES ONLY
@@ -36,10 +41,6 @@ const (
 	// ClusterDeploymentManagedLabel is the label the clusterdeployment will have that determines
 	// if the cluster is OSD (managed) or not
 	ClusterDeploymentManagedLabel string = "api.openshift.com/managed"
-	// ClusterDeploymentNoalertsLabel is the label the clusterdeployment will have if the cluster should not send alerts
-	ClusterDeploymentNoalertsLabel string = "ext-managed.openshift.io/noalerts"
-	// ClusterDeploymentNoalertsLabelOld is the OLD label used and will be remoed as a part of https://issues.redhat.com/browse/OSD-4059
-	ClusterDeploymentNoalertsLabelOld string = "api.openshift.com/noalerts"
 )
 
 // Name is used to generate the name of secondary resources (SyncSets,

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -67,15 +67,26 @@ objects:
       namespace: pagerduty-operator
     clusterDeploymentSelector:
       matchExpressions:
+      # only create PD service for managed (OSD) clusters
       - key: api.openshift.com/managed
         operator: In
         values: ["true"]
+      # ignore CD for specific organizations
       - key: api.openshift.com/legal-entity-id
         operator: NotIn
         values: ${{SILENT_ALERT_LEGALENTITY_IDS}}
+      # ignore CD for any "nightly" clusters
       - key: api.openshift.com/channel-group
         operator: NotIn
         values: ["nightly"]
+      # ignore CD w/ "legacy" noalerts label
+      - key: api.openshift.com/noalerts
+        operator: NotIn
+        values: ["true"]
+      # ignore CD w/ ext noalerts label
+      - key: ext-managed.openshift.io/noalerts
+        operator: NotIn
+        values: ["true"]
     targetSecretRef:
       name: pd-secret
       namespace: openshift-monitoring
@@ -94,12 +105,22 @@ objects:
       namespace: pagerduty-operator
     clusterDeploymentSelector:
       matchExpressions:
+      # only create PD service for managed (OSD) clusters
       - key: api.openshift.com/managed
         operator: In
         values: ["true"]
+      # for the "silent" PDI, create when CD in specific organizations we ignore in the "osd" (regular) PDI
       - key: api.openshift.com/legal-entity-id
         operator: In
         values: ${{SILENT_ALERT_LEGALENTITY_IDS}}
+      # ignore CD w/ "legacy" noalerts label
+      - key: api.openshift.com/noalerts
+        operator: NotIn
+        values: ["true"]
+      # ignore CD w/ ext noalerts label
+      - key: ext-managed.openshift.io/noalerts
+        operator: NotIn
+        values: ["true"]
     targetSecretRef:
       name: pd-secret
       namespace: openshift-monitoring

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
@@ -47,7 +47,7 @@ func (r *ReconcilePagerDutyIntegration) handleCreate(pdclient pd.Client, pdi *pa
 		// creation of resources for a ClusterDeployment, and each one
 		// will need a finalizer here. We add a suffix of the CR
 		// name to distinguish them.
-		finalizer string = "pd.managed.openshift.io/" + pdi.Name
+		finalizer string = config.PagerDutyFinalizerPrefix + pdi.Name
 	)
 
 	if !cd.Spec.Installed {

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
@@ -43,7 +43,7 @@ func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pa
 		// creation of resources for a ClusterDeployment, and each one
 		// will need a finalizer here. We add a suffix of the CR
 		// name to distinguish them.
-		finalizer string = "pd.managed.openshift.io/" + pdi.Name
+		finalizer string = config.PagerDutyFinalizerPrefix + pdi.Name
 	)
 
 	if cd == nil {
@@ -160,9 +160,9 @@ func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pa
 		}
 	}
 
-	if utils.HasFinalizer(cd, config.OperatorFinalizer) {
+	if utils.HasFinalizer(cd, config.LegacyPagerDutyFinalizer) {
 		r.reqLogger.Info("Deleting old PD finalizer from ClusterDeployment", "Namespace", cd.Namespace, "Name", cd.Name)
-		utils.DeleteFinalizer(cd, config.OperatorFinalizer)
+		utils.DeleteFinalizer(cd, config.LegacyPagerDutyFinalizer)
 		err = r.client.Update(context.TODO(), cd)
 		if err != nil {
 			metrics.UpdateMetricPagerDutyDeleteFailure(1, ClusterID, pdi.Name)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -15,12 +15,8 @@ import (
 
 // HasFinalizer returns true if the given object has the given finalizer
 func HasFinalizer(object metav1.Object, finalizer string) bool {
-	for _, f := range object.GetFinalizers() {
-		if f == finalizer {
-			return true
-		}
-	}
-	return false
+	finalizers := sets.NewString(object.GetFinalizers()...)
+	return finalizers.Has(finalizer)
 }
 
 // AddFinalizer adds a finalizer to the given object


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-5594

Unit tests were reworked to cover many more permitations.
Noalerts was removed as part of test rework / simplification.  Therefore this incorporates https://github.com/openshift/pagerduty-operator/pull/124 which will be closed.