### PR TITLE
OSD-6070 Patch clusterdeployment instead of update

### DIFF
--- a/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
@@ -16,6 +16,7 @@ package pagerdutyintegration
 
 import (
 	"context"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -56,8 +57,9 @@ func (r *ReconcilePagerDutyIntegration) handleCreate(pdclient pd.Client, pdi *pa
 	}
 
 	if !utils.HasFinalizer(cd, finalizer) {
+		baseToPatch := client.MergeFrom(cd.DeepCopy())
 		utils.AddFinalizer(cd, finalizer)
-		return r.client.Update(context.TODO(), cd)
+		return r.client.Patch(context.TODO(), cd, baseToPatch)
 	}
 
 	ClusterID := cd.Spec.ClusterName


### PR DESCRIPTION
### What type of PR is this?
Refactor

### What this PR does / why we need it?
This PR changes the logic of the `pagerduty-operator` to perform a `Patch()` of the `clusterdeployment` CR when adding or removing finalizers, rather than an `Update()`, in order to eliminate the possibility that the `Update()` call will drop data from the CR.

### Which Jira/Github issue(s) this PR fixes?
[OSD-6070](https://issues.redhat.com/browse/OSD-6070)

### Special notes for your reviewer:
I've tested this with a local deployment of `pagerduty-operator` and verified that finalizers are still created and removed as expected. I have also verified that - if the Hive `clusterdeployment` CRD introduces a new field and sets that value in a `clusterdeployment` CR - the currently running operator does not remove that new field when it performs the `Patch()`, as per the goals of [OSD-6070](https://issues.redhat.com/browse/OSD-6070).

Related PRs:
- [DeadmansSnitch](https://github.com/openshift/deadmanssnitch-operator/pull/99)
- [Certman](https://github.com/openshift/certman-operator/pull/175)

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
