### PR TITLE
Add scale test PagerdutyIntegration

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -18,6 +18,12 @@ parameters:
   required: true
 - name: SILENT_ALERT_LEGALENTITY_IDS
   value: '["None"]'
+- name: SCALE_TEST_SERVICE_PREFIX
+  required: true
+- name: SCALE_TEST_ESCALATION_POLICY
+  required: true
+- name: SCALE_TEST_LEGALENTITY_IDS
+  value: '["None"]'
 - name: CHANNEL
   value: staging
 - name: IMAGE_TAG
@@ -52,6 +58,44 @@ objects:
     source: pagerduty-operator-catalog
     sourceNamespace: pagerduty-operator
 
+- apiVersion: pagerduty.openshift.io/v1alpha1
+  kind: PagerDutyIntegration
+  metadata:
+    name: osd-scale-test
+    namespace: pagerduty-operator
+  spec:
+    acknowledgeTimeout: ${{ACKNOWLEDGE_TIMEOUT}}
+    resolveTimeout: ${{RESOLVE_TIMEOUT}}
+    escalationPolicy: ${{SCALE_TEST_ESCALATION_POLICY}}
+    servicePrefix: ${{SCALE_TEST_SERVICE_PREFIX}}
+    pagerdutyApiKeySecretRef:
+      name: pagerduty-api-key
+      namespace: pagerduty-operator
+    clusterDeploymentSelector:
+      matchExpressions:
+      # only create PD service for managed (OSD) clusters
+      - key: api.openshift.com/managed
+        operator: In
+        values: ["true"]
+      # select specific organizations
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{SCALE_TEST_LEGALENTITY_IDS}}
+      # ignore CD for any "nightly" clusters
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values: ["nightly"]
+      # ignore CD w/ "legacy" noalerts label
+      - key: api.openshift.com/noalerts
+        operator: NotIn
+        values: ["true"]
+      # ignore CD w/ ext noalerts label
+      - key: ext-managed.openshift.io/noalerts
+        operator: NotIn
+        values: ["true"]
+    targetSecretRef:
+      name: pd-secret
+      namespace: openshift-monitoring
 - apiVersion: pagerduty.openshift.io/v1alpha1
   kind: PagerDutyIntegration
   metadata:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -115,7 +115,11 @@ objects:
       - key: api.openshift.com/managed
         operator: In
         values: ["true"]
-      # ignore CD for specific organizations
+      # ignore CD if its a scale test organization, scale test org has its own PDI
+      - key: api.openshift.com/legal-entity-id
+        operator: NotIn
+        values: ${{SCALE_TEST_LEGALENTITY_IDS}}
+      # ignore CD for alerts we wish to route to the silence PD escalation policy
       - key: api.openshift.com/legal-entity-id
         operator: NotIn
         values: ${{SILENT_ALERT_LEGALENTITY_IDS}}
@@ -153,6 +157,10 @@ objects:
       - key: api.openshift.com/managed
         operator: In
         values: ["true"]
+      # ignore CD if its a scale test organization, scale test org has its own PDI
+      - key: api.openshift.com/legal-entity-id
+        operator: NotIn
+        values: ${{SCALE_TEST_LEGALENTITY_IDS}}
       # for the "silent" PDI, create when CD in specific organizations we ignore in the "osd" (regular) PDI
       - key: api.openshift.com/legal-entity-id
         operator: In


### PR DESCRIPTION
This PR adds a PagerDutyInegration CR that will select all managed clusters that have a specific organization ID and route them to a new scale test PD escalation policy.

The organization ID will be a specific org that we use for scale tests its added via parameter in the OC template in this [MR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/15310) 