### PR TITLE
Use The origin-operator-registry latest Base Image

### DIFF
--- a/build/Dockerfile.catalog_registry
+++ b/build/Dockerfile.catalog_registry
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-operator-registry:4.5
+FROM quay.io/openshift/origin-operator-registry:latest
 
 ARG SRC_BUNDLES
 


### PR DESCRIPTION
This addresses a vulnerability with regards to the 4.x origin-operator-registry image

https://issues.redhat.com/browse/OSD-6834