### PR TITLE
Revert "Revert "OSD-6853: CatalogSource by digest""

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -28,6 +28,8 @@ parameters:
   value: staging
 - name: IMAGE_TAG
   value: latest
+- name: REPO_DIGEST
+  required: true
 
 objects:
 - apiVersion: operators.coreos.com/v1alpha1
@@ -36,7 +38,7 @@ objects:
     name: pagerduty-operator-catalog
   spec:
     sourceType: grpc
-    image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
+    image: ${REPO_DIGEST}
     displayName: pagerduty-operator Registry
     publisher: SRE
 


### PR DESCRIPTION
Reverts openshift/pagerduty-operator#146

The blocking [issue](https://github.com/app-sre/sretoolbox/pull/34) has been [fixed](https://github.com/app-sre/sretoolbox/pull/35) and promoted through [qontract-reconcile](https://github.com/app-sre/qontract-reconcile/pull/1515) and [app-interface](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/18070/diffs). The saas file change has been [unreverted](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/18105).