### PR TITLE
[WIP]refactor: apply multinamespacecachebuilder

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -29,9 +29,7 @@ spec:
               cpu: "100m"
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: "pagerduty-operator"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -88,8 +88,8 @@ var (
 
 // UpdateAPIMetrics updates all API endpoint metrics every 5 minutes
 func UpdateAPIMetrics(APIKey string, timer *prometheus.Timer) {
-	d := time.Tick(5 * time.Minute)
-	for range d {
+	d := time.NewTicker(5 * time.Minute)
+	for range d.C {
 		UpdateMetricPagerDutyHeartbeat(APIKey, timer)
 	}
 


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OHSS-5537

**Theory**:
Currently, the PD operator is watching `_all_` namespaces even though the _WATCH_NAMESPACE_ is being filled up.
ref: https://github.com/openshift/pagerduty-operator/blob/master/cmd/manager/main.go#L101 

```
field Namespace string
(manager.Options).Namespace on pkg.go.dev

Namespace if specified restricts the manager's cache to watch objects in the desired namespace Defaults to all namespaces

Note: If a namespace is specified, controllers can still Watch for a cluster-scoped resource (e.g Node). For namespaced resources the cache will only hold objects from the desired namespace
```

**A possible fix**: Would it be appropriate to use `MultiNamespacedCacheBuilder`(similar to: https://issues.redhat.com/browse/OSD-7118) as _pagerdutyintegrations_ are only placed under `pagerduty-operator` ns and that's the only active ns that PD operator watches.

**Downside of having static cache:**
PD needs to watch
1) their own ns
2) uhc-.... namespaces

Whereas 1 is immutable, 2 is dynamic. Would it be possible to set this dynamically?


```
oc get pagerdutyintegrations -A
NAMESPACE            NAME                                 AGE
pagerduty-operator   addon-managed-api-service            93d
pagerduty-operator   addon-managed-api-service-internal   93d
pagerduty-operator   addon-managed-kafka                  93d
pagerduty-operator   addon-managed-kafka-qe               40d
pagerduty-operator   addon-managed-odh                    93d
pagerduty-operator   addon-ocs-converged                  44d
pagerduty-operator   osd                                  334d
pagerduty-operator   osd-scale-test                       155d
pagerduty-operator   osd-silent                           279d
```


**Tests**:
```
build/_output/bin/pagerduty-operator
{"level":"info","ts":1627469272.3354847,"logger":"cmd","msg":"Go Version: go1.16.5"}
{"level":"info","ts":1627469272.3355024,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1627469272.3355057,"logger":"cmd","msg":"Version of operator-sdk: v0.17.2"}
{"level":"info","ts":1627469272.3474615,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1627469272.3474975,"logger":"leader","msg":"Skipping leader election; not running in a cluster."}
{"level":"error","ts":1627469272.3475032,"logger":"cmd","msg":"Failed to get watch namespace","error":"WATCH_NAMESPACE must be set","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:132\nmain.main\n\tsrc/github.com/boranx/pagerduty-operator/cmd/manager/main.go:105\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:225"}
```

```
WATCH_NAMESPACE="pagerduty-operator" build/_output/bin/pagerduty-operator
{"level":"info","ts":1627469300.2332444,"logger":"cmd","msg":"Go Version: go1.16.5"}
{"level":"info","ts":1627469300.233263,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1627469300.2332695,"logger":"cmd","msg":"Version of operator-sdk: v0.17.2"}
{"level":"info","ts":1627469300.2438982,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1627469300.24393,"logger":"leader","msg":"Skipping leader election; not running in a cluster."}
I0728 12:48:23.703887   36710 request.go:645] Throttling request took 1.048402495s, request: GET:https://api-backplane.apps.hivep02ue1.p0r5.p1.openshiftapps.com/backplane/cluster/1farlonnersks14ohfp155uoonupr9id/apis/storage.k8s.io/v1?timeout=32s
{"level":"info","ts":1627469306.4920864,"logger":"cmd","msg":"Registering Components."}
{"level":"info","ts":1627469306.493917,"logger":"userMetrics","msg":"Starting prometheus metrics"}
{"level":"info","ts":1627469306.4941092,"logger":"userMetrics","msg":"Port: 8081"}
{"level":"info","ts":1627469310.9464066,"logger":"userMetrics","msg":"Generated metrics service object"}
.
.
```