### PR TITLE
OSD-8440 - Fix for orphaned incidents in PagerDuty

### DIFF
--- a/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
@@ -123,6 +123,7 @@ func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pa
 		err = pdclient.DeleteService(pdData)
 		if err != nil {
 			r.reqLogger.Error(err, "Failed cleaning up pagerduty.")
+			return err
 		} else {
 			// NOTE: not deleting the configmap if we didn't delete
 			// the service with the assumption that the config can

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -386,9 +386,9 @@ OUTER:
 				continue OUTER
 			}
 		}
-		break
+		return 
 	}
-	return
+	return errors.New("Incidents still pending")
 }
 
 func (c *SvcClient) resolveIncident(serviceKey, incidentKey string) error {

--- a/pkg/pagerduty/service_test.go
+++ b/pkg/pagerduty/service_test.go
@@ -120,7 +120,7 @@ func TestDeleteServiceTwoPendingIncidentsResolveTimeout(t *testing.T) {
 	setupMockWithIncidents(mockPdClient, funcMock, 10)
 	funcMock.On("delay").Times(5)
 	err := c.DeleteService(NewPdData())
-	assert.Equal(t, err, nil, "Unexpected error occured")
+	assert.Error(t, err, "Incidents still pending")
 	funcMock.AssertNumberOfCalls(t, "manageEvents", 2)
 	funcMock.AssertNumberOfCalls(t, "delay", 5)
 }


### PR DESCRIPTION
When deleting a cluster, we delete incidents before deleting the underlying service in PD and as this is an asynchronous event on PD side, we are waiting to confirm incident closure.
However, in case the incidents don't get closed within the defined maxWait, we continue with the service deletion which lead to orphaned incidents we cannot delete. 
Instead, we should raise an error in case the incidents didn't get closed in time : 
- in case the incidents got eventually deleted, the cleanup will proceed properly with next reconcile
- in case the event got dropped, the operator will send again the closure event which should go through