### PR TITLE
OSD-9041 fixes cm name for osd-silent

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -149,7 +149,7 @@ objects:
     acknowledgeTimeout: ${{ACKNOWLEDGE_TIMEOUT}}
     resolveTimeout: ${{RESOLVE_TIMEOUT}}
     escalationPolicy: ${{ESCALATION_POLICY_SILENT}}
-    servicePrefix: ${SERVICE_PREFIX}_silent
+    servicePrefix: ${SERVICE_PREFIX}-silent
     pagerdutyApiKeySecretRef:
       name: pagerduty-api-key
       namespace: pagerduty-operator


### PR DESCRIPTION
PD operator is unable to create configmap for this service due to RFC violation using `_` 

The configmap name is bult from ServicePrefix

```
/home/dofinn/go/src/github.com/openshift/pagerduty-operator/config/config.go
31:     ConfigMapSuffix          string = "-pd-config"

/home/dofinn/go/src/github.com/openshift/pagerduty-operator/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
46:             configMapName string = config.Name(pdi.Spec.ServicePrefix, cd.Name, config.ConfigMapSuffix)

/home/dofinn/go/src/github.com/openshift/pagerduty-operator/pkg/controller/pagerdutyintegration/clusterdeployment_hibernated.go
30:             configMapName string = config.Name(pdi.Spec.ServicePrefix, cd.Name, config.ConfigMapSuffix)

/home/dofinn/go/src/github.com/openshift/pagerduty-operator/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
46:             configMapName string = config.Name(pdi.Spec.ServicePrefix, cd.Name, config.ConfigMapSuffix)
```

