### PR TITLE
OSD-10025: Disable PagerDuty service when a cluster is in limited support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,10 @@ const (
 	// ClusterDeploymentManagedLabel is the label the clusterdeployment will have that determines
 	// if the cluster is OSD (managed) or not
 	ClusterDeploymentManagedLabel string = "api.openshift.com/managed"
+
+	// ClusterDeploymentLimitedSupportLabel is the label the clusterdeployment will have that determines
+	// if the cluster's pagerduty service needs to enabled/disabled for alerting
+	ClusterDeploymentLimitedSupportLabel string = "api.openshift.com/limited-support"
 )
 
 // Name is used to generate the name of secondary resources (SyncSets,

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
@@ -122,7 +122,7 @@ func (r *ReconcilePagerDutyIntegration) handleCreate(pdclient pd.Client, pdi *pa
 		r.reqLogger.Info("Creating configmap")
 
 		// save config map
-		newCM := kube.GenerateConfigMap(cd.Namespace, configMapName, pdData.ServiceID, pdData.IntegrationID, false)
+		newCM := kube.GenerateConfigMap(cd.Namespace, configMapName, pdData.ServiceID, pdData.IntegrationID, false, false)
 		if err = controllerutil.SetControllerReference(cd, newCM, r.scheme); err != nil {
 			r.reqLogger.Error(err, "Error setting controller reference on configmap")
 			return err

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
@@ -37,28 +37,28 @@ func (r *ReconcilePagerDutyIntegration) handleLimitedSupport(pdclient pd.Client,
 		// Disable PD service and resolve existing service alerts if limited-support label set to true
 		r.reqLogger.Info("The cluster is in limited-support, disabling PagerDuty service", "ClusterID", pdData.ClusterID, "BaseDomain", pdData.BaseDomain)
 		if err := pdclient.DisableService(pdData); err != nil {
-			r.reqLogger.Error(err, "Error disabling pagerduty service")
+			r.reqLogger.Error(err, "Error disabling PagerDuty service")
 			return err
 		}
 
 		pdData.LimitedSupport = true
 
 		if err := pdData.SetClusterConfig(r.client, cd.Namespace, configMapName); err != nil {
-			r.reqLogger.Error(err, "Error updating cluster config", "Name", configMapName)
+			r.reqLogger.Error(err, "Error updating PagerDuty cluster config", "Name", configMapName)
 			return err
 		}
 	} else if !hasLimitedSupport && pdData.LimitedSupport {
-		// Enable PD service
+		// Enable PagerDuty service if limited-support label is-not-true/does-not-exist
 		r.reqLogger.Info("The cluster is not in limited-support, enabling PagerDuty service", "ClusterID", pdData.ClusterID, "BaseDomain", pdData.BaseDomain)
 		if err := pdclient.EnableService(pdData); err != nil {
-			r.reqLogger.Error(err, "Error enabling pagerduty service")
+			r.reqLogger.Error(err, "Error enabling PagerDuty service")
 			return err
 		}
 
 		pdData.LimitedSupport = false
 
 		if err := pdData.SetClusterConfig(r.client, cd.Namespace, configMapName); err != nil {
-			r.reqLogger.Error(err, "Error updating pd cluster config", "Name", configMapName)
+			r.reqLogger.Error(err, "Error updating PagerDuty cluster config", "Name", configMapName)
 			return err
 		}
 	}

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
@@ -39,7 +39,7 @@ func (r *ReconcilePagerDutyIntegration) handleLimitedSupport(pdclient pd.Client,
 			r.reqLogger.Error(err, "Error updating cluster config", "Name", configMapName)
 			return err
 		}
-	} else if ok && hasLimitedSupport == "false" {
+	} else if ok {
 		// Re-enable the pagerduty service if limited-support label set to false
 		r.reqLogger.Info("Limited-support set to false, enabling PD service", "ClusterID", pdData.ClusterID, "BaseDomain", pdData.BaseDomain)
 		if err := pdclient.EnableService(pdData); err != nil {

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
@@ -33,7 +33,7 @@ func (r *ReconcilePagerDutyIntegration) handleLimitedSupport(pdclient pd.Client,
 		hasLimitedSupport = val
 	}
 
-	if hasLimitedSupport && !pdData.ServiceDisabled {
+	if hasLimitedSupport && !pdData.LimitedSupport {
 		// Disable PD service and resolve existing service alerts if limited-support label set to true
 		r.reqLogger.Info("The cluster is in limited-support, disabling PagerDuty service", "ClusterID", pdData.ClusterID, "BaseDomain", pdData.BaseDomain)
 		if err := pdclient.DisableService(pdData); err != nil {
@@ -41,13 +41,13 @@ func (r *ReconcilePagerDutyIntegration) handleLimitedSupport(pdclient pd.Client,
 			return err
 		}
 
-		pdData.ServiceDisabled = true
+		pdData.LimitedSupport = true
 
 		if err := pdData.SetClusterConfig(r.client, cd.Namespace, configMapName); err != nil {
 			r.reqLogger.Error(err, "Error updating cluster config", "Name", configMapName)
 			return err
 		}
-	} else if !hasLimitedSupport && pdData.ServiceDisabled {
+	} else if !hasLimitedSupport && pdData.LimitedSupport {
 		// Enable PD service
 		r.reqLogger.Info("The cluster is not in limited-support, enabling PagerDuty service", "ClusterID", pdData.ClusterID, "BaseDomain", pdData.BaseDomain)
 		if err := pdclient.EnableService(pdData); err != nil {
@@ -55,7 +55,7 @@ func (r *ReconcilePagerDutyIntegration) handleLimitedSupport(pdclient pd.Client,
 			return err
 		}
 
-		pdData.ServiceDisabled = false
+		pdData.LimitedSupport = false
 
 		if err := pdData.SetClusterConfig(r.client, cd.Namespace, configMapName); err != nil {
 			r.reqLogger.Error(err, "Error updating pd cluster config", "Name", configMapName)

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
@@ -1,0 +1,56 @@
+package pagerdutyintegration
+
+import (
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/pagerduty-operator/config"
+	pagerdutyv1alpha1 "github.com/openshift/pagerduty-operator/pkg/apis/pagerduty/v1alpha1"
+	pd "github.com/openshift/pagerduty-operator/pkg/pagerduty"
+)
+
+func (r *ReconcilePagerDutyIntegration) handleLimitedSupport(pdclient pd.Client, pdi *pagerdutyv1alpha1.PagerDutyIntegration, cd *hivev1.ClusterDeployment) error {
+	// configMapName is the name of the ConfigMap of the relevant service
+	var configMapName = config.Name(pdi.Spec.ServicePrefix, cd.Name, config.ConfigMapSuffix)
+
+	// check if the cluster isn't installed yet
+	if !cd.Spec.Installed {
+		// if the cluster hasn't been installed yet, return
+		return nil
+	}
+
+	// PagerDuty data
+	pdData := &pd.Data{}
+	err := pdData.ParseClusterConfig(r.client, cd.Namespace, configMapName)
+	if err != nil || pdData.ServiceID == "" {
+		// pagerduty service isn't created yet, return
+		return nil
+	}
+
+	// Check if limited-support label exists in CD
+	hasLimitedSupport, ok := cd.Labels[config.ClusterDeploymentLimitedSupportLabel]
+
+	if ok && hasLimitedSupport == "true" {
+		// Disable pagerduty service and resolve existing service alerts if limited-support label set to true
+		r.reqLogger.Info("Limited-support set to true, disabling pagerduty service", "ClusterID", pdData.ClusterID, "BaseDomain", pdData.BaseDomain)
+		if err := pdclient.DisableService(pdData); err != nil {
+			r.reqLogger.Error(err, "Error disabling pagerduty service")
+			return err
+		}
+		if err := pdData.SetClusterConfig(r.client, cd.Namespace, configMapName); err != nil {
+			r.reqLogger.Error(err, "Error updating cluster config", "Name", configMapName)
+			return err
+		}
+	} else if ok && hasLimitedSupport == "false" {
+		// Re-enable the pagerduty service if limited-support label set to false
+		r.reqLogger.Info("Limited-support set to false, enabling PD service", "ClusterID", pdData.ClusterID, "BaseDomain", pdData.BaseDomain)
+		if err := pdclient.EnableService(pdData); err != nil {
+			r.reqLogger.Error(err, "Error enabling pagerduty service")
+			return err
+		}
+		if err := pdData.SetClusterConfig(r.client, cd.Namespace, configMapName); err != nil {
+			r.reqLogger.Error(err, "Error updating pd cluster config", "Name", configMapName)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
+++ b/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
@@ -294,6 +294,10 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 			if err := r.handleHibernation(pdClient, pdi, &cd); err != nil {
 				return r.requeueOnErr(err)
 			}
+
+			if err := r.handleLimitedSupport(pdClient, pdi, &cd); err != nil {
+				return r.requeueOnErr(err)
+			}
 		}
 	}
 

--- a/pkg/kube/configmap.go
+++ b/pkg/kube/configmap.go
@@ -22,17 +22,17 @@ import (
 )
 
 // GenerateConfigMap returns a configmap that can be created with the oc client
-func GenerateConfigMap(namespace string, cmName string, pdServiceID string, pdIntegrationID string, hibernating bool, serviceDisabled bool) *corev1.ConfigMap {
+func GenerateConfigMap(namespace string, cmName string, pdServiceID string, pdIntegrationID string, hibernating bool, limitedSupport bool) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			"SERVICE_ID":       pdServiceID,
-			"INTEGRATION_ID":   pdIntegrationID,
-			"HIBERNATING":      strconv.FormatBool(hibernating),
-			"SERVICE_DISABLED": strconv.FormatBool(serviceDisabled),
+			"SERVICE_ID":      pdServiceID,
+			"INTEGRATION_ID":  pdIntegrationID,
+			"HIBERNATING":     strconv.FormatBool(hibernating),
+			"LIMITED_SUPPORT": strconv.FormatBool(limitedSupport),
 		},
 	}
 }

--- a/pkg/kube/configmap.go
+++ b/pkg/kube/configmap.go
@@ -15,22 +15,24 @@
 package kube
 
 import (
+	"strconv"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 )
 
 // GenerateConfigMap returns a configmap that can be created with the oc client
-func GenerateConfigMap(namespace string, cmName string, pdServiceID string, pdIntegrationID string, hibernating bool) *corev1.ConfigMap {
+func GenerateConfigMap(namespace string, cmName string, pdServiceID string, pdIntegrationID string, hibernating bool, serviceDisabled bool) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			"SERVICE_ID":     pdServiceID,
-			"INTEGRATION_ID": pdIntegrationID,
-			"HIBERNATING": strconv.FormatBool(hibernating),
+			"SERVICE_ID":       pdServiceID,
+			"INTEGRATION_ID":   pdIntegrationID,
+			"HIBERNATING":      strconv.FormatBool(hibernating),
+			"SERVICE_DISABLED": strconv.FormatBool(serviceDisabled),
 		},
 	}
 }

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -141,10 +141,10 @@ type Data struct {
 	ClusterID          string
 	BaseDomain         string
 
-	ServiceID       string
-	IntegrationID   string
-	Hibernating     bool
-	ServiceDisabled bool
+	ServiceID      string
+	IntegrationID  string
+	Hibernating    bool
+	LimitedSupport bool
 }
 
 // ParseClusterConfig parses the cluster specific config map and stores the IDs in the data struct
@@ -168,8 +168,8 @@ func (data *Data) ParseClusterConfig(osc client.Client, namespace string, cmName
 	val := pdAPIConfigMap.Data["HIBERNATING"]
 	data.Hibernating = val == "true"
 
-	isServiceDisabled := pdAPIConfigMap.Data["SERVICE_DISABLED"]
-	data.ServiceDisabled = isServiceDisabled == "true"
+	isInLimitedSupport := pdAPIConfigMap.Data["LIMITED_SUPPORT"]
+	data.LimitedSupport = isInLimitedSupport == "true"
 
 	return nil
 }
@@ -184,7 +184,7 @@ func (data *Data) SetClusterConfig(osc client.Client, namespace string, cmName s
 	pdAPIConfigMap.Data["SERVICE_ID"] = data.ServiceID
 	pdAPIConfigMap.Data["INTEGRATION_ID"] = data.IntegrationID
 	pdAPIConfigMap.Data["HIBERNATING"] = strconv.FormatBool(data.Hibernating)
-	pdAPIConfigMap.Data["SERVICE_DISABLED"] = strconv.FormatBool(data.ServiceDisabled)
+	pdAPIConfigMap.Data["LIMITED_SUPPORT"] = strconv.FormatBool(data.LimitedSupport)
 
 	if err := osc.Update(context.TODO(), pdAPIConfigMap); err != nil {
 		return err

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -79,7 +79,7 @@ type PdClient interface {
 	ListServices(pdApi.ListServiceOptions) (*pdApi.ListServiceResponse, error)
 	ListIncidents(pdApi.ListIncidentsOptions) (*pdApi.ListIncidentsResponse, error)
 	ListIncidentAlerts(incidentId string) (*pdApi.ListAlertsResponse, error)
-	UpdateService(service pdApi.Service)  (*pdApi.Service, error)
+	UpdateService(service pdApi.Service) (*pdApi.Service, error)
 }
 
 type ManageEventFunc func(pdApi.V2Event) (*pdApi.V2EventResponse, error)
@@ -141,9 +141,10 @@ type Data struct {
 	ClusterID          string
 	BaseDomain         string
 
-	ServiceID     string
-	IntegrationID string
-	Hibernating   bool
+	ServiceID       string
+	IntegrationID   string
+	Hibernating     bool
+	ServiceDisabled bool
 }
 
 // ParseClusterConfig parses the cluster specific config map and stores the IDs in the data struct
@@ -167,6 +168,9 @@ func (data *Data) ParseClusterConfig(osc client.Client, namespace string, cmName
 	val := pdAPIConfigMap.Data["HIBERNATING"]
 	data.Hibernating = val == "true"
 
+	isServiceDisabled := pdAPIConfigMap.Data["SERVICE_DISABLED"]
+	data.ServiceDisabled = isServiceDisabled == "true"
+
 	return nil
 }
 
@@ -180,6 +184,7 @@ func (data *Data) SetClusterConfig(osc client.Client, namespace string, cmName s
 	pdAPIConfigMap.Data["SERVICE_ID"] = data.ServiceID
 	pdAPIConfigMap.Data["INTEGRATION_ID"] = data.IntegrationID
 	pdAPIConfigMap.Data["HIBERNATING"] = strconv.FormatBool(data.Hibernating)
+	pdAPIConfigMap.Data["SERVICE_DISABLED"] = strconv.FormatBool(data.ServiceDisabled)
 
 	if err := osc.Update(context.TODO(), pdAPIConfigMap); err != nil {
 		return err
@@ -386,7 +391,7 @@ OUTER:
 				continue OUTER
 			}
 		}
-		return 
+		return
 	}
 	return errors.New("Incidents still pending")
 }


### PR DESCRIPTION
Resolves: [OSD-10025](https://issues.redhat.com/browse/OSD-10025)
<hr>

- This PR switches the PagerDuty service enabled/disabled based on the `api.openshift.com/limited-support` label in the cluster deployment.
- When `api.openshift.com/limited-support` is set to **true** the cluster related PagerDuty service is disabled and any active alerts are automatically resolved.
- When `api.openshift.com/limited-support` is set to anything else other than true or if the label is deleted the cluster related PagerDuty service is re-enabled and alerting is resumed.