### PR TITLE
Update PDI to not alert for 'limited-support' clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -143,6 +143,10 @@ objects:
       - key: ext-managed.openshift.io/noalerts
         operator: NotIn
         values: ["true"]
+      # ignore CD w/ limited-support label
+      - key: api.openshift.com/limited-support
+        operator: NotIn
+        values: ["true"]
     targetSecretRef:
       name: pd-secret
       namespace: openshift-monitoring


### PR DESCRIPTION
Resolves: [OSD-10025](https://issues.redhat.com/browse/OSD-10025)
<hr>

This PR updates the PagerDuty integration template to ensure that a PD service is deleted if the cluster is in limited-support. (aka do not page SRE)
More context in the JIRA.