### PR TITLE
[OSD-10189] Simplify GetSecretKey and getConfigMapKey

### DIFF
--- a/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
@@ -125,7 +125,7 @@ func (r *ReconcilePagerDutyIntegration) handleCreate(pdclient pd.Client, pdi *pa
 		r.reqLogger.Info("Creating configmap")
 
 		// save config map
-		newCM := kube.GenerateConfigMap(cd.Namespace, configMapName, pdData.ServiceID, pdData.IntegrationID, pdData.EsclationPolicyID, false, false)
+		newCM := kube.GenerateConfigMap(cd.Namespace, configMapName, pdData.ServiceID, pdData.IntegrationID, pdData.EscalationPolicyID, false, false)
 		if err = controllerutil.SetControllerReference(cd, newCM, r.scheme); err != nil {
 			r.reqLogger.Error(err, "Error setting controller reference on configmap")
 			return err
@@ -144,7 +144,7 @@ func (r *ReconcilePagerDutyIntegration) handleCreate(pdclient pd.Client, pdi *pa
 	}
 
 	// check if there is a change in PDI escalation policy
-	if pdData.PDIEscalationPolicyID != pdData.EsclationPolicyID {
+	if pdData.PDIEscalationPolicyID != pdData.EscalationPolicyID {
 		r.reqLogger.Info("PDI EscalationPolicy changed, updating service")
 		err := pdclient.UpdateEscalationPolicy(pdData)
 		if err != nil {
@@ -152,9 +152,9 @@ func (r *ReconcilePagerDutyIntegration) handleCreate(pdclient pd.Client, pdi *pa
 			return err
 		}
 
-		pdData.EsclationPolicyID = pdData.PDIEscalationPolicyID
+		pdData.EscalationPolicyID = pdData.PDIEscalationPolicyID
 
-		// Update configmap to reflect the new esclation policy changes
+		// Update configmap to reflect the new escalation policy changes
 		if err := pdData.SetClusterConfig(r.client, cd.Namespace, configMapName); err != nil {
 			r.reqLogger.Error(err, "Error updating PagerDuty cluster config", "Name", configMapName)
 			return err

--- a/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller_test.go
+++ b/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller_test.go
@@ -300,7 +300,7 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 					func(data *pd.Data) (string, error) {
 						data.ServiceID = "XYZ123"
 						data.IntegrationID = "LMN456"
-						data.EsclationPolicyID = testEscalationPolicy
+						data.EscalationPolicyID = testEscalationPolicy
 						return data.IntegrationID, nil
 					})
 				r.GetIntegrationKey(gomock.Any()).Return(testIntegrationID, nil).Times(1)
@@ -322,7 +322,7 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 					func(data *pd.Data) (string, error) {
 						data.ServiceID = "XYZ123"
 						data.IntegrationID = "LMN456"
-						data.EsclationPolicyID = testEscalationPolicy
+						data.EscalationPolicyID = testEscalationPolicy
 						return data.IntegrationID, nil
 					})
 				r.GetIntegrationKey(gomock.Any()).Return(testIntegrationID, nil).Times(1)
@@ -364,7 +364,7 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 					func(data *pd.Data) (string, error) {
 						data.ServiceID = "XYZ123"
 						data.IntegrationID = "LMN456"
-						data.EsclationPolicyID = testEscalationPolicy
+						data.EscalationPolicyID = testEscalationPolicy
 						return data.IntegrationID, nil
 					}) // unit test not support "lookup"
 				r.GetIntegrationKey(gomock.Any()).Return(testIntegrationID, nil).Times(0) // secret already exists, won't recreate
@@ -580,7 +580,7 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 					func(data *pd.Data) (string, error) {
 						data.ServiceID = "XYZ123"
 						data.IntegrationID = "LMN456"
-						data.EsclationPolicyID = testEscalationPolicy
+						data.EscalationPolicyID = testEscalationPolicy
 						return data.IntegrationID, nil
 					})
 				r.GetIntegrationKey(gomock.Any()).Return(testIntegrationID, nil).Times(1)

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -32,29 +32,27 @@ import (
 )
 
 func getConfigMapKey(data map[string]string, key string) (string, error) {
-	if _, ok := data[key]; !ok {
-		errorStr := fmt.Sprintf("%v does not exist", key)
-		return "", errors.New(errorStr)
+	retString, ok := data[key]
+	if !ok {
+		return "", fmt.Errorf("%v does not exist", key)
 	}
-	retString := data[key]
-	if len(retString) <= 0 {
-		errorStr := fmt.Sprintf("%v is empty", key)
-		return "", errors.New(errorStr)
+	if len(retString) == 0 {
+		return "", fmt.Errorf("%v is empty", key)
 	}
+
 	return retString, nil
 }
 
 func GetSecretKey(data map[string][]byte, key string) (string, error) {
-	if _, ok := data[key]; !ok {
-		errorStr := fmt.Sprintf("%v does not exist", key)
-		return "", errors.New(errorStr)
+	retString, ok := data[key]
+	if !ok {
+		return "", fmt.Errorf("%v does not exist", key)
 	}
-	retString := string(data[key])
-	if len(retString) <= 0 {
-		errorStr := fmt.Sprintf("%v is empty", key)
-		return "", errors.New(errorStr)
+	if len(retString) == 0 {
+		return "", fmt.Errorf("%v is empty", key)
 	}
-	return retString, nil
+
+	return string(retString), nil
 }
 
 //Client is a wrapper interface for the SvcClient to allow for easier testing


### PR DESCRIPTION
After unit tests are in place from #180 and #181 (shouldn't be merged before those two),

Correct a typo and simplify `getConfigMapKey` and `GetSecretKey`