### PR TITLE
[OSD-9561] Scrub PD service names for FedRamp clusters

### DIFF
--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -229,8 +229,8 @@ func (c *SvcClient) CreateService(data *Data) (string, error) {
 	}
 
 	clusterService := pdApi.Service{
-		Name:                   data.ServicePrefix + "-" + data.ClusterID + "." + data.BaseDomain + "-hive-cluster",
-		Description:            data.ClusterID + " - A managed hive created cluster",
+		Name:                   generatePDServiceName(data),
+		Description:            generatePDServiceDescription(data),
 		EscalationPolicy:       *escalationPolicy,
 		AutoResolveTimeout:     &data.AutoResolveTimeout,
 		AcknowledgementTimeout: &data.AcknowledgeTimeOut,
@@ -451,6 +451,26 @@ func parseIncidentNumbers(incidents []pdApi.Incident) []uint {
 	}
 
 	return incidentNumbers
+}
+
+// generateServiceName checks if FedRamp is enabled. If it is, it returns
+// an anonymized PD service name.
+func generatePDServiceName(data *Data) string {
+	if config.IsFedramp() {
+		return data.ClusterID
+	} else {
+		return data.ServicePrefix + "-" + data.ClusterID + "." + data.BaseDomain + "-hive-cluster"
+	}
+}
+
+// generateServiceDescription checks if FedRamp is enabled. If it is, it returns
+// an empty PD service description
+func generatePDServiceDescription(data *Data) string {
+	if config.IsFedramp() {
+		return ""
+	} else {
+		return data.ClusterID + " - A managed hive created cluster"
+	}
 }
 
 func (c *SvcClient) resolveIncident(serviceKey, incidentKey string) error {


### PR DESCRIPTION
This resolves an issue with the changes made to anonymize pagerduty services for the story https://issues.redhat.com/browse/OSD-9561. This updates the `service` package to check for the presence of a `FEDRAMP` environment variable. If present and true, the PD service name is set to the internal cluster ID and the description will be left blank. If `FEDRAMP` is false, the pre-existing service names and descriptions are used. 