### PR TITLE
[OSD-10751] Fix bug where the operator was failing to delete some alerts

### DIFF
--- a/pkg/pagerduty/service_mock.go
+++ b/pkg/pagerduty/service_mock.go
@@ -1,0 +1,314 @@
+// This contains a minimal mock PagerDuty API for testing this package in
+// ways that the GoMock version in mock_service.go.
+// TODO: Build out this minimal mock so that the pagerdutyintegration package
+// can utilize this instead of the GoMock variant as well.
+
+package pagerduty
+
+import (
+	"encoding/json"
+	"fmt"
+	pd "github.com/PagerDuty/go-pagerduty"
+	"net/http"
+	"net/http/httptest"
+)
+
+const (
+	mockEscalationPolicyId string = "ESC1"
+	mockIncidentId         string = "INC1"
+	mockIntegrationId      string = "INT1"
+	mockServiceId          string = "SVC1"
+)
+
+type mockSvcClient struct {
+	SvcClient
+}
+
+// withTestHttpClient is meant to be used with httptest when testing to pass a mock http client
+func withTestHttpClient(testClient *http.Client) pd.ClientOptions {
+	return func(c *pd.Client) {
+		c.HTTPClient = testClient
+	}
+}
+
+func newMockClient(server *httptest.Server) *mockSvcClient {
+	return &mockSvcClient{
+		SvcClient{
+			APIKey: "apiKey",
+			PdClient: pd.NewClient(
+				"apiKey",
+				withTestHttpClient(server.Client()),
+				pd.WithAPIEndpoint(server.URL),
+			),
+		},
+	}
+}
+
+// setupMock creates a mock with behavior to respond to largely get/list requests on mock objects
+// whose names are constants in this package, e.g. mockServiceId, mockIncidentId
+func setupMock() (*mockSvcClient, *httptest.Server, *http.ServeMux) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	setupCreateServiceHandler(mux)
+	setupDefaultServiceHandlers(mux)
+	setupDefaultListIncidentsHandler(mux)
+	setupDefaultGetEscalationPolicyHandler(mux)
+
+	return newMockClient(server), server, mux
+}
+
+// setupMockWithServices extends the default mock with a slice of provided services
+func setupMockWithServices(services []*pd.Service) (*mockSvcClient, *httptest.Server, *http.ServeMux) {
+	mock, server, mux := setupMock()
+	for _, service := range services {
+		setupServiceHandlers(mux, *service)
+	}
+
+	return mock, server, mux
+}
+
+// setupDefaultServiceHandlers sets up handlers to get and update a mock service with ID mockServiceId
+// as well as creating integrations for that service
+func setupDefaultServiceHandlers(mux *http.ServeMux) {
+	serviceData := map[string]pd.Service{
+		"service": {
+			APIObject: pd.APIObject{
+				ID: mockServiceId,
+			},
+			Status: "disabled",
+		},
+	}
+	mux.HandleFunc(fmt.Sprintf("/services/%s", mockServiceId), func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			// Get default mock service
+			resp, err := json.Marshal(serviceData)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(resp)
+			if err != nil {
+				return
+			}
+		case http.MethodPut:
+			// Update default mock service
+			var serviceData map[string]pd.Service
+			err := json.NewDecoder(r.Body).Decode(&serviceData)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			service, ok := serviceData["service"]
+			if !ok {
+				http.Error(w, "Could not find expected key: service", http.StatusBadRequest)
+				return
+			}
+			service.ID = mockServiceId
+			processedService := map[string]pd.Service{
+				"service": service,
+			}
+
+			resp, err := json.Marshal(processedService)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, err = w.Write(resp)
+			if err != nil {
+				return
+			}
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	setupCreateIntegrationHandler(mux, mockServiceId)
+}
+
+// setupDefaultListIncidentsHandler sets up a handler to respond to listing incidents for mockServiceId
+func setupDefaultListIncidentsHandler(mux *http.ServeMux) {
+	incidentsData := map[string][]pd.Incident{
+		"incidents": {
+			{
+				Id:     mockIncidentId,
+				Status: "triggered",
+				Service: pd.APIObject{
+					ID: mockServiceId,
+				},
+				AlertCounts: pd.AlertCounts{
+					All:       2,
+					Triggered: 1,
+					Resolved:  1,
+				},
+				EscalationPolicy: pd.APIObject{
+					ID: mockEscalationPolicyId,
+				},
+			},
+		},
+	}
+
+	mux.HandleFunc("/incidents", func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(incidentsData)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(resp)
+		if err != nil {
+			return
+		}
+	})
+}
+
+// setupCreateServiceHandler sets up a handler to respond to creating a service
+func setupCreateServiceHandler(mux *http.ServeMux) {
+	mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
+		var serviceData map[string]pd.Service
+
+		err := json.NewDecoder(r.Body).Decode(&serviceData)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		service, ok := serviceData["service"]
+		if !ok {
+			http.Error(w, "Could not find expected key: service", http.StatusBadRequest)
+			return
+		}
+		service.ID = mockServiceId
+		processedService := map[string]pd.Service{
+			"service": service,
+		}
+
+		resp, err := json.Marshal(processedService)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, err = w.Write(resp)
+		if err != nil {
+			return
+		}
+	})
+}
+
+// setupDefaultGetEscalationPolicyHandler sets up a mock escalation policy to interact with since the PagerDuty operator
+// expects an escalation policy to already exist.
+func setupDefaultGetEscalationPolicyHandler(mux *http.ServeMux) {
+	escalationPolicyData := map[string]pd.EscalationPolicy{
+		"escalation_policy": {
+			APIObject: pd.APIObject{
+				ID: mockIntegrationId,
+			},
+			Services: []pd.APIObject{
+				{
+					ID: mockServiceId,
+				},
+			},
+		},
+	}
+	mux.HandleFunc(fmt.Sprintf("/escalation_policies/%s", mockEscalationPolicyId), func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(escalationPolicyData)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(resp)
+		if err != nil {
+			return
+		}
+	})
+}
+
+// setupCreateIntegrationHandler sets up a handler to create new integrations for a provided service ID
+func setupCreateIntegrationHandler(mux *http.ServeMux, serviceId string) {
+	mux.HandleFunc(fmt.Sprintf("/services/%s/integrations", serviceId), func(w http.ResponseWriter, r *http.Request) {
+		var integrationData map[string]pd.Integration
+
+		err := json.NewDecoder(r.Body).Decode(&integrationData)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		integration, ok := integrationData["integration"]
+		if !ok {
+			http.Error(w, "Could not find expected key: integration", http.StatusBadRequest)
+			return
+		}
+		integration.ID = mockIntegrationId
+		processedIntegration := map[string]pd.Integration{
+			"integration": integration,
+		}
+
+		resp, err := json.Marshal(processedIntegration)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, err = w.Write(resp)
+		if err != nil {
+			return
+		}
+	})
+}
+
+// setupServiceHandlers sets up a handler to get a provided service as well as any integrations of the service
+func setupServiceHandlers(mux *http.ServeMux, service pd.Service) {
+	if service.APIObject.ID == "" {
+		panic("service is missing required field: ID")
+	}
+	svcData := map[string]pd.Service{
+		"service": service,
+	}
+	mux.HandleFunc(fmt.Sprintf("/services/%s", service.APIObject.ID), func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(svcData)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(resp)
+		if err != nil {
+			return
+		}
+	})
+
+	setupIntegrationsHandlers(mux, service)
+}
+
+// setupIntegrationsHandlers sets up a handler for mocking get integration calls for a provided service
+func setupIntegrationsHandlers(mux *http.ServeMux, service pd.Service) {
+	setupCreateIntegrationHandler(mux, service.APIObject.ID)
+
+	for _, integration := range service.Integrations {
+		if integration.APIObject.ID == "" {
+			panic("integration is missing required field: ID")
+		}
+		integrationData := map[string]pd.Integration{
+			"integration": integration,
+		}
+		mux.HandleFunc(fmt.Sprintf("/services/%s/integrations/%s", service.APIObject.ID, integration.APIObject.ID), func(w http.ResponseWriter, r *http.Request) {
+			resp, err := json.Marshal(integrationData)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(resp)
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/pagerduty/service_test.go
+++ b/pkg/pagerduty/service_test.go
@@ -2,127 +2,14 @@ package pagerduty
 
 import (
 	"testing"
-	"time"
 
-	pdApi "github.com/PagerDuty/go-pagerduty"
-	"github.com/golang/mock/gomock"
+	pd "github.com/PagerDuty/go-pagerduty"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-type functionMock struct {
-	mock.Mock
-}
-
-func (m *functionMock) manageEvents(pdApi.V2Event) (*pdApi.V2EventResponse, error) {
-	args := m.Called()
-	return args.Get(0).(*pdApi.V2EventResponse), args.Error(1)
-}
-
-func (m *functionMock) delay(d time.Duration) {
-	m.Called()
-}
-
-func NewTestClient(t *testing.T) (Client, *MockPdClient, *functionMock) {
-	mockClient := NewMockPdClient(gomock.NewController(t))
-	funcMock := new(functionMock)
-	return &SvcClient{
-			APIKey:      "test-key",
-			PdClient:    mockClient,
-			ManageEvent: func(ev pdApi.V2Event) (*pdApi.V2EventResponse, error) { return funcMock.manageEvents(ev) },
-			Delay:       func(d time.Duration) { funcMock.delay(d) },
-		},
-		mockClient,
-		funcMock
-}
-
-func NewPdData() *Data {
-	return &Data{
-		APIKey:        "test-api-key",
-		ClusterID:     "test-cluster-id",
-		BaseDomain:    "test.domain",
-		ServiceID:     "test-service-id",
-		IntegrationID: "test-integration-id",
-	}
-}
-
-func setupMockWithIncidents(mockPdClient *MockPdClient, funcMock *functionMock, eventDelay int) {
-	incidentsResponse := &pdApi.ListIncidentsResponse{
-		Incidents: []pdApi.Incident{
-			incident("test-incident-1", 1),
-			incident("test-incident-2", 1),
-		},
-	}
-	incidentsResponseResolved := &pdApi.ListIncidentsResponse{
-		Incidents: []pdApi.Incident{
-			incident("test-incident-1", 0),
-			incident("test-incident-2", 0),
-		},
-	}
-	integration := &pdApi.Integration{
-		IntegrationKey: "test-integration-key",
-	}
-	alert1 := &pdApi.ListAlertsResponse{
-		Alerts: []pdApi.IncidentAlert{{}},
-	}
-	alert2 := &pdApi.ListAlertsResponse{
-		Alerts: []pdApi.IncidentAlert{{}},
-	}
-	mockPdClient.EXPECT().ListIncidents(gomock.Any()).Return(incidentsResponse, nil).Times(eventDelay)
-	mockPdClient.EXPECT().GetIntegration("test-service-id", "test-integration-id", gomock.Any()).Return(integration, nil).Times(1)
-	mockPdClient.EXPECT().ListIncidents(gomock.Any()).Return(incidentsResponseResolved, nil).Times(1)
-	mockPdClient.EXPECT().ListIncidentAlerts("test-incident-1").Return(alert1, nil).Times(1)
-	mockPdClient.EXPECT().ListIncidentAlerts("test-incident-2").Return(alert2, nil).Times(1)
-	mockPdClient.EXPECT().DeleteService(gomock.Any()).Return(nil).Times(1)
-	funcMock.On("manageEvents").Return(&pdApi.V2EventResponse{}, nil).Times(2)
-}
-
-func incident(name string, triggeredCount uint) pdApi.Incident {
-	return pdApi.Incident{
-		Id: name,
-		AlertCounts: pdApi.AlertCounts{
-			Triggered: triggeredCount,
-		},
-	}
-
-}
-
-func TestDeleteService(t *testing.T) {
-	tests := []struct {
-		name             string
-		eventDelay       int
-		initialDelay     int
-		expectError      bool
-		expectedNumCalls int
-	}{
-		{
-			name:             "Two pending incidents",
-			eventDelay:       1,
-			initialDelay:     0,
-			expectError:      false,
-			expectedNumCalls: 2,
-		},
-	}
-
-	for _, test := range tests {
-		c, mockPdClient, funcMock := NewTestClient(t)
-		setupMockWithIncidents(mockPdClient, funcMock, test.eventDelay)
-		funcMock.On("delay").Times(test.initialDelay)
-		err := c.DeleteService(NewPdData())
-		if test.expectError {
-			assert.NotNilf(t, err, "expected '%s' to return an error", test.name)
-		} else {
-			assert.Nilf(t, err, "expected '%s' to return nil", test.name)
-		}
-
-		funcMock.AssertNumberOfCalls(t, "manageEvents", test.expectedNumCalls)
-		funcMock.AssertNumberOfCalls(t, "delay", test.initialDelay)
-	}
-}
 
 func TestGetConfigMapKey(t *testing.T) {
 	tests := []struct {
@@ -287,4 +174,259 @@ func TestParseSetClusterConfig(t *testing.T) {
 		setErr := testData.SetClusterConfig(client, test.namespace, test.cmName)
 		assert.Nil(t, setErr)
 	}
+}
+
+func TestSvcClient_GetService(t *testing.T) {
+	mockServices := []*pd.Service{
+		{
+			APIObject: pd.APIObject{
+				ID: "1",
+			},
+			Name: "one",
+		},
+	}
+
+	tests := []struct {
+		serviceId string
+		expectErr bool
+	}{
+		{
+			serviceId: "1",
+			expectErr: false,
+		},
+		{
+			serviceId: "notfound",
+			expectErr: true,
+		},
+	}
+
+	mock, server, _ := setupMockWithServices(mockServices)
+
+	for _, test := range tests {
+		_, err := mock.GetService(&Data{ServiceID: test.serviceId})
+		if test.expectErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+		}
+	}
+
+	server.Close()
+}
+
+func TestSvcClient_GetIntegrationKey(t *testing.T) {
+	mockServices := []*pd.Service{
+		{
+			APIObject: pd.APIObject{
+				ID: "1",
+			},
+			Name: "one",
+			Integrations: []pd.Integration{
+				{
+					APIObject: pd.APIObject{
+						ID: "1",
+					},
+					Name:           "oneIntegration",
+					IntegrationKey: "oneIntegrationKey",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		serviceId     string
+		integrationId string
+		expected      string
+		expectErr     bool
+	}{
+		{
+			serviceId:     "1",
+			integrationId: "1",
+			expected:      "oneIntegrationKey",
+			expectErr:     false,
+		},
+		{
+			serviceId:     "1",
+			integrationId: "notfound",
+			expectErr:     true,
+		},
+	}
+
+	mock, server, _ := setupMockWithServices(mockServices)
+
+	for _, test := range tests {
+		actual, err := mock.GetIntegrationKey(&Data{ServiceID: test.serviceId, IntegrationID: test.integrationId})
+		if test.expectErr {
+			assert.NotNil(t, err)
+			assert.Equal(t, test.expected, actual)
+		} else {
+			assert.Nil(t, err)
+		}
+	}
+
+	server.Close()
+}
+
+func TestSvcClient_CreateIntegration(t *testing.T) {
+	mockServices := []*pd.Service{
+		{
+			APIObject: pd.APIObject{
+				ID: "1",
+			},
+			Name: "one",
+		},
+	}
+
+	tests := []struct {
+		serviceId       string
+		integrationName string
+		integrationType string
+		expectErr       bool
+	}{
+		{
+			serviceId:       "1",
+			integrationName: "integrationName",
+			integrationType: "events_api_v2_inbound_integration",
+			expectErr:       false,
+		},
+		{
+			serviceId: "2",
+			expectErr: true,
+		},
+	}
+
+	mock, server, _ := setupMockWithServices(mockServices)
+
+	for _, test := range tests {
+		actual, err := mock.createIntegration(test.serviceId, test.integrationName, test.integrationType)
+		if test.expectErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, mockIntegrationId, actual)
+		}
+	}
+
+	server.Close()
+}
+
+func TestSvcClient_CreateService(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      *Data
+		expectErr bool
+	}{
+		{
+			name: "Works",
+			data: &Data{
+				PDIEscalationPolicyID: mockEscalationPolicyId,
+				AutoResolveTimeout:    30,
+				AcknowledgeTimeOut:    30,
+				ServicePrefix:         "servicePrefix",
+				ClusterID:             "clusterID",
+				BaseDomain:            "baseDomain",
+			},
+			expectErr: false,
+		},
+		{
+			name: "Can't find escalation policy",
+			data: &Data{
+				PDIEscalationPolicyID: "notfound",
+			},
+			expectErr: true,
+		},
+	}
+
+	mock, server, _ := setupMock()
+
+	for _, test := range tests {
+		_, err := mock.CreateService(test.data)
+		if test.expectErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+		}
+	}
+
+	server.Close()
+}
+
+func TestSvcClient_EnableService(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      *Data
+		expectErr bool
+	}{
+		{
+			name: "Works",
+			data: &Data{
+				ServiceID: mockServiceId,
+			},
+			expectErr: false,
+		},
+		{
+			name: "Can't find service",
+			data: &Data{
+				ServiceID: "notfound",
+			},
+			expectErr: true,
+		},
+	}
+
+	mock, server, _ := setupMock()
+
+	for _, test := range tests {
+		err := mock.EnableService(test.data)
+		if test.expectErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+		}
+	}
+
+	server.Close()
+}
+
+func TestSvcClient_UpdateEscalationPolicy(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      *Data
+		expectErr bool
+	}{
+		{
+			name: "normal",
+			data: &Data{
+				PDIEscalationPolicyID: mockEscalationPolicyId,
+				ServiceID:             mockServiceId,
+			},
+			expectErr: false,
+		},
+		{
+			name: "missing escalation policy",
+			data: &Data{
+				PDIEscalationPolicyID: "notfound",
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing service",
+			data: &Data{
+				PDIEscalationPolicyID: mockEscalationPolicyId,
+				ServiceID:             "notfound",
+			},
+			expectErr: true,
+		},
+	}
+
+	mock, server, _ := setupMock()
+	for _, test := range tests {
+		err := mock.UpdateEscalationPolicy(test.data)
+		if test.expectErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+		}
+	}
+
+	server.Close()
 }


### PR DESCRIPTION
This bug occurs sometimes when a PagerDuty service has more than one integration because `GetIntegrationKey` returns only one integration, while `resolveAlert` (renamed from `resolveIncident`) needs a correct integration key + alert key combination to successfully resolve an alert.

This was not too obvious because the PagerDuty Events V2 API (which `resolveAlert` uses) returns an HTTP 202 (success) regardless if the integration key + alert key combination matches, the API simply acknowledges that the event was received and contains all the necessary arguments. Luckily, alerts themselves indicate the integration that generated them, so the fix wasn't too bad (can isolate onto the second commit for the entire fix). I validated this fix locally by identifying clusters were failing to have alerts resolve (all had two integrations), then tried to resolve them via the Events V2 API locally (https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI2Nw-send-an-event-to-pager-duty) with the "other" integration key with the specified alert and was able to see the alert resolve.

However, it was quite difficult for me to build up enough knowledge to get here due to the lack of "useful" unit tests, so I built them up to a point where I finally understood enough to identify the problem. I don't have a unit test for the fixed function itself yet as I would need to mock the stateful action of resolving an alert, which can be done, but I figured that since this is an ongoing problem that it should be resolved first and the tests can continue to be fleshed out.