### PR TITLE
[OSD-10189] Accumulate errors during the reconcile loop instead of immediately bailing

### DIFF
--- a/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/pagerduty-operator/config"
 	pagerdutyv1alpha1 "github.com/openshift/pagerduty-operator/pkg/apis/pagerduty/v1alpha1"
@@ -28,6 +26,7 @@ import (
 	pd "github.com/openshift/pagerduty-operator/pkg/pagerduty"
 	"github.com/openshift/pagerduty-operator/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pagerdutyv1alpha1.PagerDutyIntegration, cd *hivev1.ClusterDeployment) error {
@@ -78,7 +77,6 @@ func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pa
 
 	// Check if the PD Service still exists, if not DeleteService returns errors
 	if deletePDService {
-		// Check if the PD service still exists
 		_, err = pdclient.GetService(pdData)
 
 		if err != nil {
@@ -86,8 +84,6 @@ func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pa
 				return err
 			}
 			r.reqLogger.Info(fmt.Sprintf("PD service %s-%s.%s not found...skipping PD service deletion", pdData.ServicePrefix, pdData.ClusterID, pdData.BaseDomain))
-
-			// If the PagerDuty service is not found, don't try deleting it and continue cleaning up
 			deletePDService = false
 		}
 	}
@@ -95,23 +91,19 @@ func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pa
 	// None of the edge cases apply, delete the PagerDuty service
 	if deletePDService {
 		r.reqLogger.Info(fmt.Sprintf("Deleting PD service %s-%s.%s", pdData.ServicePrefix, pdData.ClusterID, pdData.BaseDomain))
-		err = pdclient.DeleteService(pdData)
-		if err != nil {
+		if err := pdclient.DeleteService(pdData); err != nil {
 			r.reqLogger.Error(err, "Failed cleaning up pagerduty.", "ClusterDeployment.Namespace", cd.Namespace, "ClusterID", pdData.ClusterID)
 			return err
-		} else {
-			// NOTE: not deleting the configmap if we didn't delete
-			// the service with the assumption that the config can
-			// be used later for cleanup find the PD configmap and
-			// delete it
-			r.reqLogger.Info("Deleting PD ConfigMap", "ClusterDeployment.Namespace", cd.Namespace, "Name", configMapName)
-			err = utils.DeleteConfigMap(configMapName, cd.Namespace, r.client, r.reqLogger)
+		}
 
-			if err != nil {
-				r.reqLogger.Error(err, "Error deleting ConfigMap", "ClusterDeployment.Namespace", cd.Namespace, "Name", configMapName)
-			}
+		// Only delete the configmap if the PagerDuty service was successfully deleted because
+		// it contains the service ID which can be used to find and delete the service next time.
+		r.reqLogger.Info("Deleting PD ConfigMap", "ClusterDeployment.Namespace", cd.Namespace, "Name", configMapName)
+		if err := utils.DeleteConfigMap(configMapName, cd.Namespace, r.client, r.reqLogger); err != nil {
+			r.reqLogger.Error(err, "Error deleting ConfigMap", "ClusterDeployment.Namespace", cd.Namespace, "Name", configMapName)
 		}
 	}
+
 	// find the pd secret and delete id
 	r.reqLogger.Info("Deleting PD secret", "ClusterDeployment.Namespace", cd.Namespace, "Name", secretName)
 	err = utils.DeleteSecret(secretName, cd.Namespace, r.client, r.reqLogger)

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
@@ -78,6 +78,7 @@ func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pa
 
 	// Check if the PD Service still exists, if not DeleteService returns errors
 	if deletePDService {
+		// Check if the PD service still exists
 		_, err = pdclient.GetService(pdData)
 
 		if err != nil {
@@ -85,6 +86,8 @@ func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pa
 				return err
 			}
 			r.reqLogger.Info(fmt.Sprintf("PD service %s-%s.%s not found...skipping PD service deletion", pdData.ServicePrefix, pdData.ClusterID, pdData.BaseDomain))
+
+			// If the PagerDuty service is not found, don't try deleting it and continue cleaning up
 			deletePDService = false
 		}
 	}

--- a/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
+++ b/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
@@ -16,6 +16,7 @@ package pagerdutyintegration
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -43,6 +44,22 @@ const (
 )
 
 var log = logf.Log.WithName("controller_pagerdutyintegration")
+
+// pdiReconcileErrors implements the builtin error interface
+type pdiReconcileErrors []error
+
+// Error causes pdiReconcileErrors to convert the error to a string like normal unless its length is more than one.
+// Then it will print the first error and report the remaining number of errors.
+func (p pdiReconcileErrors) Error() string {
+	switch len(p) {
+	case 0:
+		return ""
+	case 1:
+		return p[0].Error()
+	default:
+		return fmt.Sprintf("%s - %d other errors", p[0].Error(), len(p)-1)
+	}
+}
 
 // Add creates a new PagerDutyIntegration Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -181,7 +198,7 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 		return r.requeueOnErr(err)
 	}
 
-	// fetch matching CDs
+	// Fetch ClusterDeployments matching the PDI's ClusterDeployment label selector
 	matchingClusterDeployments, err := r.getMatchingClusterDeployments(pdi)
 	if err != nil {
 		return r.requeueOnErr(err)
@@ -205,12 +222,9 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 	localmetrics.UpdateMetricPagerDutyIntegrationSecretLoaded(1, pdi.Name)
 	pdClient := r.pdclient(pdApiKey, controllerName)
 
-	// check if PDI is being deleted, if so we cleanup all CD w/ matching finalizers
+	// If the PDI is being deleted, clean up all ClusterDeployments with matching finalizers
 	if pdi.DeletionTimestamp != nil {
 		if utils.HasFinalizer(pdi, config.PagerDutyIntegrationFinalizer) {
-			// review _all_ CD, cleanup anything w/ this PDI finalizer
-
-			// do the CD cleanup
 			for _, clusterdeployment := range allClusterDeployments.Items {
 				if utils.HasFinalizer(&clusterdeployment, clusterDeploymentFinalizerName) {
 					err = r.handleDelete(pdClient, pdi, &clusterdeployment)
@@ -222,7 +236,7 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 
 			localmetrics.DeleteMetricPagerDutyIntegrationSecretLoaded(pdi.Name)
 
-			// do the PDI cleanup
+			// Once all ClusterDeployments have been cleaned up, delete the PDI finalizer
 			utils.DeleteFinalizer(pdi, config.PagerDutyIntegrationFinalizer)
 			err = r.client.Update(context.TODO(), pdi)
 			if err != nil {
@@ -232,7 +246,7 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 		return r.doNotRequeue()
 	}
 
-	// add finalizer to PDI if it's not there (if we get here, it's not being deleted)
+	// Ensure the PDI has a finalizer to protect it from deletion
 	if !utils.HasFinalizer(pdi, config.PagerDutyIntegrationFinalizer) {
 		utils.AddFinalizer(pdi, config.PagerDutyIntegrationFinalizer)
 		err := r.client.Update(context.TODO(), pdi)
@@ -241,18 +255,18 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 		}
 	}
 
-	// review all CD and see if PD service needs to be deleted
+	var reconcileErrors pdiReconcileErrors
+	// Process all ClusterDeployments with the PDI finalizer for PD service deletion
 	for _, cd := range allClusterDeployments.Items {
 		if utils.HasFinalizer(&cd, clusterDeploymentFinalizerName) {
 			if cd.DeletionTimestamp != nil {
-				// it has a finalizer and is being deleted.  clean up PD things!
+				// The ClusterDeployment is being deleted, so delete the PD service
 				err := r.handleDelete(pdClient, pdi, &cd)
 				if err != nil {
-					return r.requeueOnErr(err)
+					reconcileErrors = append(reconcileErrors, err)
 				}
 			} else {
-				// it has a finalizer and is NOT being deleted.
-				// check if it should have PD setup or not (did it drop out of the PDI?)
+				// The ClusterDeployment is NOT being deleted, is it one of our matched ClusterDeployments?
 				cdIsMatching := false
 				for _, mcd := range matchingClusterDeployments.Items {
 					if cd.Namespace == mcd.Namespace && cd.Name == mcd.Name {
@@ -261,11 +275,12 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 					}
 				}
 
+				// It's not a matched ClusterDeployment, delete the PagerDuty service because it shouldn't exist
 				if !cdIsMatching {
-					// the CD has a finalizer but is NOT matching the PDI. clean it up.
+					r.reqLogger.Info(fmt.Sprintf("cleaning up %s as it has a finalizer but no matching label", cd.Name))
 					err := r.handleDelete(pdClient, pdi, &cd)
 					if err != nil {
-						return r.requeueOnErr(err)
+						reconcileErrors = append(reconcileErrors, err)
 					}
 				}
 			}
@@ -276,20 +291,20 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 	for _, cd := range matchingClusterDeployments.Items {
 		if cd.DeletionTimestamp == nil {
 			if err := r.handleCreate(pdClient, pdi, &cd); err != nil {
-				return r.requeueOnErr(err)
+				reconcileErrors = append(reconcileErrors, err)
 			}
 
 			if err := r.handleHibernation(pdClient, pdi, &cd); err != nil {
-				return r.requeueOnErr(err)
+				reconcileErrors = append(reconcileErrors, err)
 			}
 
 			if err := r.handleLimitedSupport(pdClient, pdi, &cd); err != nil {
-				return r.requeueOnErr(err)
+				reconcileErrors = append(reconcileErrors, err)
 			}
 		}
 	}
 
-	return r.doNotRequeue()
+	return r.requeueOnErr(reconcileErrors)
 }
 
 func (r *ReconcilePagerDutyIntegration) getAllClusterDeployments() (*hivev1.ClusterDeploymentList, error) {

--- a/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller_test.go
+++ b/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller_test.go
@@ -720,9 +720,9 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 			})
 
 			// Assert
-			assert.NoError(t, err1, "Unexpected Error with Reconcile (1 of 3)")
-			assert.NoError(t, err2, "Unexpected Error with Reconcile (2 of 3)")
-			assert.NoError(t, err3, "Unexpected Error with Reconcile (3 of 3)")
+			assert.Nil(t, err1, "Unexpected Error with Reconcile (1 of 3)")
+			assert.Nil(t, err2, "Unexpected Error with Reconcile (2 of 3)")
+			assert.Nil(t, err3, "Unexpected Error with Reconcile (3 of 3)")
 			if test.expectPDSetup {
 				// should see a syncset, secret, configmap, and finalizer on CD
 				assert.True(t, verifySyncSetExists(mocks.fakeKubeClient, expectedSyncSet), "verifySyncSets: "+test.name)

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -44,18 +44,6 @@ func getConfigMapKey(data map[string]string, key string) (string, error) {
 	return retString, nil
 }
 
-func GetSecretKey(data map[string][]byte, key string) (string, error) {
-	retString, ok := data[key]
-	if !ok {
-		return "", fmt.Errorf("%v does not exist", key)
-	}
-	if len(retString) == 0 {
-		return "", fmt.Errorf("%v is empty", key)
-	}
-
-	return string(retString), nil
-}
-
 //Client is a wrapper interface for the SvcClient to allow for easier testing
 type Client interface {
 	GetService(data *Data) (*pdApi.Service, error)

--- a/pkg/pagerduty/service_test.go
+++ b/pkg/pagerduty/service_test.go
@@ -55,50 +55,6 @@ func TestGetConfigMapKey(t *testing.T) {
 	}
 }
 
-func TestGetSecretKey(t *testing.T) {
-	tests := []struct {
-		name        string
-		data        map[string][]byte
-		key         string
-		expected    string
-		expectError bool
-	}{
-		{
-			name: "Normal",
-			data: map[string][]byte{
-				"key": []byte("value"),
-			},
-			key:         "key",
-			expected:    "value",
-			expectError: false,
-		},
-		{
-			name: "Empty",
-			data: map[string][]byte{
-				"key": []byte(""),
-			},
-			key:         "key",
-			expectError: true,
-		},
-		{
-			name:        "Does not exist",
-			data:        map[string][]byte{},
-			key:         "key",
-			expectError: true,
-		},
-	}
-
-	for _, test := range tests {
-		actual, err := GetSecretKey(test.data, test.key)
-		if test.expectError {
-			assert.NotNil(t, err)
-		} else {
-			assert.Equal(t, test.expected, actual)
-			assert.Nil(t, err)
-		}
-	}
-}
-
 func TestNewData(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/utils/secrets.go
+++ b/pkg/utils/secrets.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"crypto/md5"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -10,22 +9,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// LoadSecretData loads a given secret key and returns it's data as a string.
+// LoadSecretData loads a given secret key and returns its data as a string.
 func LoadSecretData(c client.Client, secretName, namespace, dataKey string) (string, error) {
 	s := &corev1.Secret{}
-	err := c.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: namespace}, s)
-	if err != nil {
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: namespace}, s); err != nil {
 		return "", err
 	}
+
 	retStr, ok := s.Data[dataKey]
 	if !ok {
 		return "", fmt.Errorf("secret %s did not contain key %s", secretName, dataKey)
 	}
-	return string(retStr), nil
-}
+	if len(retStr) == 0 {
+		return "", fmt.Errorf("%s is empty", dataKey)
+	}
 
-// GetHashOfPullSecret returns md5 sum of a string
-func GetHashOfPullSecret(data string) string {
-	bData := []byte(data)
-	return fmt.Sprintf("%x", md5.Sum(bData))
+	return string(retStr), nil
 }


### PR DESCRIPTION
The main idea is to accumulate errors in a new `type pdiReconcileErrors []error` which implements the builtin error interface, allowing a full reconcile loop to complete before requeuing.

This is important because the operator effectively tries to reconcile all ClusterDeployments each time, attempting delete actions before any creates. This meant that any bugs in PagerDuty service deletion would cause the operator to be unable to attempt to create new PagerDuty services until the service deletion was remediated.

Along the way I found `utils.LoadSecretData` was duplicated by `pagerduty.GetSecretKey`, so I removed GetSecretKey. Likewise, `utils. GetHashOfPullSecret` was unused and so removed.