### PR TITLE
[OSD-10917] Default escalationpolicyid to prevent errors in deletion

### DIFF
--- a/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
@@ -95,15 +95,14 @@ func (r *ReconcilePagerDutyIntegration) handleCreate(pdclient pd.Client, pdi *pa
 		return err
 	}
 
-	pdData := &pd.Data{
-		ClusterID:             clusterID,
-		BaseDomain:            cd.Spec.BaseDomain,
-		PDIEscalationPolicyID: pdi.Spec.EscalationPolicy,
-		AutoResolveTimeout:    pdi.Spec.ResolveTimeout,
-		AcknowledgeTimeOut:    pdi.Spec.AcknowledgeTimeout,
-		ServicePrefix:         pdi.Spec.ServicePrefix,
-		APIKey:                apiKey,
+	pdData, err := pd.NewData(pdi)
+	if err != nil {
+		return err
 	}
+
+	pdData.BaseDomain = cd.Spec.BaseDomain
+	pdData.ClusterID = clusterID
+	pdData.APIKey = apiKey
 
 	// To prevent scoping issues in the err check below.
 	var pdIntegrationKey string

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
@@ -96,15 +96,14 @@ func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pa
 		return err
 	}
 
-	pdData := &pd.Data{
-		ClusterID:             clusterID,
-		BaseDomain:            cd.Spec.BaseDomain,
-		PDIEscalationPolicyID: pdi.Spec.EscalationPolicy,
-		AutoResolveTimeout:    pdi.Spec.ResolveTimeout,
-		AcknowledgeTimeOut:    pdi.Spec.AcknowledgeTimeout,
-		ServicePrefix:         pdi.Spec.ServicePrefix,
-		APIKey:                apiKey,
+	pdData, err := pd.NewData(pdi)
+	if err != nil {
+		return err
 	}
+
+	pdData.BaseDomain = cd.Spec.BaseDomain
+	pdData.ClusterID = clusterID
+	pdData.APIKey = apiKey
 
 	if deletePDService {
 		err = pdData.ParseClusterConfig(r.client, cd.Namespace, configMapName)

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_hibernated.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_hibernated.go
@@ -41,7 +41,11 @@ func (r *ReconcilePagerDutyIntegration) handleHibernation(pdclient pd.Client, pd
 		return nil
 	}
 
-	pdData := &pd.Data{}
+	pdData, err := pd.NewData(pdi)
+	if err != nil {
+		return err
+	}
+
 	if err := pdData.ParseClusterConfig(r.client, cd.Namespace, configMapName); err != nil {
 		if errors.IsNotFound(err) {
 			// service isn't created yet, return

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
@@ -20,8 +20,12 @@ func (r *ReconcilePagerDutyIntegration) handleLimitedSupport(pdclient pd.Client,
 	}
 
 	// PagerDuty data
-	pdData := &pd.Data{}
-	err := pdData.ParseClusterConfig(r.client, cd.Namespace, configMapName)
+	pdData, err := pd.NewData(pdi)
+	if err != nil {
+		return err
+	}
+
+	err = pdData.ParseClusterConfig(r.client, cd.Namespace, configMapName)
 	if err != nil || pdData.ServiceID == "" {
 		// pagerduty service isn't created yet, return
 		return nil


### PR DESCRIPTION
Created a new function, `NewData`, to default the "Data" struct to contain PDIEscalationPolicyID by default.

Then, updated `ParseClusterConfig` such that EscalationPolicyID defaults to PDIEscalationPolicyID when missing.