### PR TITLE
Increase Memory requests/limits to 2G

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,10 +22,10 @@ spec:
           imagePullPolicy: Always
           resources:
             requests:
-              memory: "800Mi"
+              memory: "2G"
               cpu: "100m"
             limits:
-              memory: "800Mi"
+              memory: "2G"
               cpu: "100m"
           env:
             - name: WATCH_NAMESPACE

--- a/manifests/05-operator.yaml
+++ b/manifests/05-operator.yaml
@@ -22,10 +22,10 @@ spec:
           imagePullPolicy: Always
           resources:
             requests:
-              memory: "800Mi"
+              memory: "2G"
               cpu: "100m"
             limits:
-              memory: "800Mi"
+              memory: "2G"
               cpu: "100m"
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
PDO is currently getting OOMKilled on hivep01ue1. Increasing the memory requests/limits here to mitigate the risk of PDO crashing.