### PR TITLE
[OSD-10917] Cleanup Data struct to remove unneeded ApiKey and require ClusterId and BaseDomain

### DIFF
--- a/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_created.go
@@ -72,31 +72,11 @@ func (r *ReconcilePagerDutyIntegration) handleCreate(pdclient pd.Client, pdi *pa
 		return r.client.Patch(context.TODO(), cd, baseToPatch)
 	}
 
-	pdAPISecret := &corev1.Secret{}
-	err := r.client.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      pdi.Spec.PagerdutyApiKeySecretRef.Name,
-			Namespace: pdi.Spec.PagerdutyApiKeySecretRef.Namespace,
-		},
-		pdAPISecret,
-	)
-	if err != nil {
-		return err
-	}
-
-	apiKey, err := pd.GetSecretKey(pdAPISecret.Data, config.PagerDutyAPISecretKey)
-	if err != nil {
-		return err
-	}
-
 	clusterID := utils.GetClusterID(cd)
 	pdData, err := pd.NewData(pdi, clusterID, cd.Spec.BaseDomain)
 	if err != nil {
 		return err
 	}
-
-	pdData.APIKey = apiKey
 
 	// load configuration
 	err = pdData.ParseClusterConfig(r.client, cd.Namespace, configMapName)

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_deleted.go
@@ -17,6 +17,8 @@ package pagerdutyintegration
 import (
 	"context"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,9 +29,7 @@ import (
 	metrics "github.com/openshift/pagerduty-operator/pkg/localmetrics"
 	pd "github.com/openshift/pagerduty-operator/pkg/pagerduty"
 	"github.com/openshift/pagerduty-operator/pkg/utils"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pagerdutyv1alpha1.PagerDutyIntegration, cd *hivev1.ClusterDeployment) error {
@@ -57,11 +57,6 @@ func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pa
 
 	if !utils.HasFinalizer(cd, finalizer) {
 		return nil
-	}
-
-	clusterID := cd.Spec.ClusterName
-	if config.IsFedramp() {
-		clusterID = utils.GetClusterID(cd.Namespace)
 	}
 
 	deletePDService := true
@@ -96,31 +91,26 @@ func (r *ReconcilePagerDutyIntegration) handleDelete(pdclient pd.Client, pdi *pa
 		return err
 	}
 
-	pdData, err := pd.NewData(pdi)
+	clusterID := utils.GetClusterID(cd)
+	pdData, err := pd.NewData(pdi, clusterID, cd.Spec.BaseDomain)
 	if err != nil {
 		return err
 	}
 
-	pdData.BaseDomain = cd.Spec.BaseDomain
-	pdData.ClusterID = clusterID
 	pdData.APIKey = apiKey
 
-	if deletePDService {
-		err = pdData.ParseClusterConfig(r.client, cd.Namespace, configMapName)
-
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				// some error other than not found, requeue
-				return err
-			}
-			/*
-				Something was not found if we are here.
-
-				The missing object will never be created as we're in the handleDelete function.
-				Skip service deletion in this case and continue with deletion.
-			*/
-			deletePDService = false
+	if err := pdData.ParseClusterConfig(r.client, cd.Namespace, configMapName); err != nil {
+		if !errors.IsNotFound(err) {
+			// some error other than not found, requeue
+			return err
 		}
+		/*
+			Something was not found if we are here.
+
+			The missing object will never be created as we're in the handleDelete function.
+			Skip service deletion in this case and continue with deletion.
+		*/
+		deletePDService = false
 	}
 
 	// Check if the PD Service still exists, if its been deleted but the PD configmap still exists,

--- a/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
+++ b/pkg/controller/pagerdutyintegration/clusterdeployment_limited_support.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/pagerduty-operator/config"
 	pagerdutyv1alpha1 "github.com/openshift/pagerduty-operator/pkg/apis/pagerduty/v1alpha1"
 	pd "github.com/openshift/pagerduty-operator/pkg/pagerduty"
+	"github.com/openshift/pagerduty-operator/pkg/utils"
 )
 
 func (r *ReconcilePagerDutyIntegration) handleLimitedSupport(pdclient pd.Client, pdi *pagerdutyv1alpha1.PagerDutyIntegration, cd *hivev1.ClusterDeployment) error {
@@ -20,7 +21,8 @@ func (r *ReconcilePagerDutyIntegration) handleLimitedSupport(pdclient pd.Client,
 	}
 
 	// PagerDuty data
-	pdData, err := pd.NewData(pdi)
+	clusterID := utils.GetClusterID(cd)
+	pdData, err := pd.NewData(pdi, clusterID, cd.Spec.BaseDomain)
 	if err != nil {
 		return err
 	}

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -134,7 +134,6 @@ type Data struct {
 	ResolveTimeout        uint
 	AcknowledgeTimeOut    uint
 	ServicePrefix         string
-	APIKey                string
 
 	// ClusterID and BaseDomain are required during service creation for naming
 	ClusterID  string

--- a/pkg/pagerduty/service_test.go
+++ b/pkg/pagerduty/service_test.go
@@ -124,7 +124,7 @@ func TestNewData(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, err := NewData(test.pdi)
+		_, err := NewData(test.pdi, "clusterId", "baseDomain")
 		if test.expectErr {
 			assert.NotNil(t, err)
 		} else {
@@ -330,7 +330,7 @@ func TestSvcClient_CreateService(t *testing.T) {
 			name: "Works",
 			data: &Data{
 				PDIEscalationPolicyID: mockEscalationPolicyId,
-				AutoResolveTimeout:    30,
+				ResolveTimeout:        30,
 				AcknowledgeTimeOut:    30,
 				ServicePrefix:         "servicePrefix",
 				ClusterID:             "clusterID",

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/pagerduty-operator/config"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -132,7 +133,11 @@ func DeleteSecret(name string, namespace string, client client.Client, reqLogger
 	return nil
 }
 
-func GetClusterID(clusterNS string) string {
-	cns := strings.Split(clusterNS, "-")
-	return cns[len(cns)-1]
+func GetClusterID(cd *hivev1.ClusterDeployment) string {
+	if config.IsFedramp() {
+		cns := strings.Split(cd.Namespace, "-")
+		return cns[len(cns)-1]
+	} else {
+		return cd.Spec.ClusterName
+	}
 }


### PR DESCRIPTION
After pushing in a fix for [OSD-10917](https://issues.redhat.com/browse/OSD-10917), we noticed some issues disabling services in stage. The first thing that came to mind was that during creation/deletion, we are setting an APIKey https://github.com/openshift/pagerduty-operator/blob/68f87792db1dcd3c9e0014793e49ea4211a1c5fd/pkg/controller/pagerdutyintegration/clusterdeployment_created.go#L105 but we weren't during the hibernation/limited_support workflows. The log message was extremely vague because `clusterId` and `baseDomain` never get set in the hibernation/limited_support workflows.

But how did this ever work? It's because the controller already sets up the PagerDuty client with an API key https://github.com/openshift/pagerduty-operator/blob/68f87792db1dcd3c9e0014793e49ea4211a1c5fd/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go#L199-L211 and nothing uses the APIKey field in the Data struct at all...

This helped better define which fields in the Data struct are required, and so I updated the `NewData` function originally created in #187 accordingly to take in `clusterId` and `baseDomain` strings and removed the `APIKey` field. This way if errors happen again for PD services being disabled, we can identify which cluster it's associated with and act on it.