### PR TITLE
OSD-10934 Fix bug preventing successful enabling/disabling of PD services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.57.0 // indirect
-	github.com/PagerDuty/go-pagerduty v1.4.0
+	github.com/PagerDuty/go-pagerduty v1.5.0
 	github.com/go-logr/logr v0.2.1
 	github.com/go-openapi/spec v0.19.4
 	github.com/golang/mock v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.6/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
-github.com/PagerDuty/go-pagerduty v1.4.0 h1:1ju+FZt47dLsm9iDU6eMymbr1TeqHmpSRU27pJ+LwQ4=
-github.com/PagerDuty/go-pagerduty v1.4.0/go.mod h1:W5hSIIPrzSgAkNBDiuymWN5g9yQVzimL7BUBL44f3RY=
+github.com/PagerDuty/go-pagerduty v1.5.0 h1:/p8FGD32G8HGm7MQIjlTPTGXRJ62Qkm8Lmt5BcUVJOo=
+github.com/PagerDuty/go-pagerduty v1.5.0/go.mod h1:txr8VbObXdk2RkqF+C2an4qWssdGY99fK26XYUDjh+4=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
@@ -395,8 +395,9 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=

--- a/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
+++ b/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
@@ -304,7 +304,11 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 		}
 	}
 
-	return r.requeueOnErr(reconcileErrors)
+	if len(reconcileErrors) > 0 {
+		return r.requeueOnErr(reconcileErrors)
+	}
+
+	return r.doNotRequeue()
 }
 
 func (r *ReconcilePagerDutyIntegration) getAllClusterDeployments() (*hivev1.ClusterDeploymentList, error) {

--- a/pkg/pagerduty/mock_service.go
+++ b/pkg/pagerduty/mock_service.go
@@ -134,6 +134,21 @@ func (mr *MockClientMockRecorder) UpdateEscalationPolicy(data interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEscalationPolicy", reflect.TypeOf((*MockClient)(nil).UpdateEscalationPolicy), data)
 }
 
+// UpdateService mocks base method
+func (m *MockClient) UpdateService(service *go_pagerduty.Service) (*go_pagerduty.Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateService", service)
+	ret0, _ := ret[0].(*go_pagerduty.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateService indicates an expected call of UpdateService
+func (mr *MockClientMockRecorder) UpdateService(service interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateService", reflect.TypeOf((*MockClient)(nil).UpdateService), service)
+}
+
 // MockPdClient is a mock of PdClient interface
 type MockPdClient struct {
 	ctrl     *gomock.Controller
@@ -276,19 +291,34 @@ func (mr *MockPdClientMockRecorder) ListIncidents(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIncidents", reflect.TypeOf((*MockPdClient)(nil).ListIncidents), arg0)
 }
 
-// ListIncidentAlerts mocks base method
-func (m *MockPdClient) ListIncidentAlerts(incidentId string) (*go_pagerduty.ListAlertsResponse, error) {
+// ListIncidentAlertsWithOpts mocks base method
+func (m *MockPdClient) ListIncidentAlertsWithOpts(incidentId string, o go_pagerduty.ListIncidentAlertsOptions) (*go_pagerduty.ListAlertsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListIncidentAlerts", incidentId)
+	ret := m.ctrl.Call(m, "ListIncidentAlertsWithOpts", incidentId, o)
 	ret0, _ := ret[0].(*go_pagerduty.ListAlertsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListIncidentAlerts indicates an expected call of ListIncidentAlerts
-func (mr *MockPdClientMockRecorder) ListIncidentAlerts(incidentId interface{}) *gomock.Call {
+// ListIncidentAlertsWithOpts indicates an expected call of ListIncidentAlertsWithOpts
+func (mr *MockPdClientMockRecorder) ListIncidentAlertsWithOpts(incidentId, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIncidentAlerts", reflect.TypeOf((*MockPdClient)(nil).ListIncidentAlerts), incidentId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIncidentAlertsWithOpts", reflect.TypeOf((*MockPdClient)(nil).ListIncidentAlertsWithOpts), incidentId, o)
+}
+
+// ManageEvent mocks base method
+func (m *MockPdClient) ManageEvent(e *go_pagerduty.V2Event) (*go_pagerduty.V2EventResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ManageEvent", e)
+	ret0, _ := ret[0].(*go_pagerduty.V2EventResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ManageEvent indicates an expected call of ManageEvent
+func (mr *MockPdClientMockRecorder) ManageEvent(e interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManageEvent", reflect.TypeOf((*MockPdClient)(nil).ManageEvent), e)
 }
 
 // UpdateService mocks base method

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -293,7 +293,9 @@ func (c *SvcClient) CreateService(data *Data) (string, error) {
 func (c *SvcClient) createIntegration(serviceId, name, integrationType string) (string, error) {
 	newIntegration := pdApi.Integration{
 		Name: name,
-		Type: integrationType,
+		APIObject: pdApi.APIObject{
+			Type: integrationType,
+		},
 	}
 
 	newInt, err := c.PdClient.CreateIntegration(serviceId, newIntegration)
@@ -389,7 +391,7 @@ func (c *SvcClient) resolvePendingIncidents(data *Data) error {
 	}
 
 	for _, incident := range incidents {
-		alerts, err := c.getUnresolvedAlerts(incident.Id)
+		alerts, err := c.getUnresolvedAlerts(incident.APIObject.ID)
 		if err != nil {
 			return err
 		}

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -53,6 +53,7 @@ type Client interface {
 	EnableService(data *Data) error
 	DisableService(data *Data) error
 	UpdateEscalationPolicy(data *Data) error
+	UpdateService(service *pdApi.Service) (*pdApi.Service, error)
 }
 
 type PdClient interface {
@@ -329,11 +330,24 @@ func (c *SvcClient) EnableService(data *Data) error {
 
 	if service.Status != "active" {
 		service.Status = "active"
-		_, err = c.PdClient.UpdateService(*service)
+		_, err = c.UpdateService(service)
 		return err
 	}
 
 	return nil
+}
+
+// UpdateService is a temporary wrapper until an upstream bug is fixed
+// AlertGroupingParameters.Type incorrectly defaults to "" when unset
+// https://github.com/PagerDuty/go-pagerduty/issues/438
+func (c *SvcClient) UpdateService(service *pdApi.Service) (*pdApi.Service, error) {
+	if service.AlertGroupingParameters != nil {
+		if service.AlertGroupingParameters.Type == "" {
+			service.AlertGroupingParameters = nil
+		}
+	}
+
+	return c.PdClient.UpdateService(*service)
 }
 
 // DisableService will set the PD service disabled
@@ -353,7 +367,7 @@ func (c *SvcClient) DisableService(data *Data) error {
 
 	if service.Status != "disabled" {
 		service.Status = "disabled"
-		if _, err = c.PdClient.UpdateService(*service); err != nil {
+		if _, err = c.UpdateService(service); err != nil {
 			return err
 		}
 	}
@@ -375,7 +389,7 @@ func (c *SvcClient) UpdateEscalationPolicy(data *Data) error {
 
 	service.EscalationPolicy.ID = escalationPolicy.ID
 
-	_, err = c.PdClient.UpdateService(*service)
+	_, err = c.UpdateService(service)
 	if err != nil {
 		return err
 	}

--- a/pkg/pagerduty/service_mock.go
+++ b/pkg/pagerduty/service_mock.go
@@ -85,7 +85,6 @@ func defaultMockPagerdutyState() *mockState {
 		},
 		Incidents: []*pd.Incident{
 			{
-				Id:        mockIncidentId,
 				APIObject: pd.APIObject{ID: mockIncidentId},
 				Service:   pd.APIObject{ID: mockServiceId},
 				Status:    "triggered",
@@ -96,7 +95,6 @@ func defaultMockPagerdutyState() *mockState {
 				},
 			},
 			{
-				Id:        mockIncidentId2,
 				APIObject: pd.APIObject{ID: mockIncidentId2},
 				Service:   pd.APIObject{ID: mockServiceId},
 				Status:    "resolved",


### PR DESCRIPTION
The three commits in this PR are for:

1. Updating go-pagerduty to v1.5.0 to pull in some fixes from https://github.com/PagerDuty/go-pagerduty/pull/384
2. It wasn't enough, so raised https://github.com/PagerDuty/go-pagerduty/issues/438 and added a wrapper function for now to get around the bug we're facing with `UpdateService`
3. At this point a full reconcile loop completed in stage for the first time in a while, with one last failure on saying `Reconcile complete` when there were no errors, so I added a `len(reconcileErrors) > 0` check