### PR TITLE
Update ConfigMap EscalationPolicyID data field on reconcile

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This operator runs on [Hive](https://github.com/openshift/hive) and watches for 
 * The PagerDutyIntegration controller watches for changes to PagerDutyIntegration CRs, and also for changes to appropriately labeled ClusterDeployment CRs (and ConfigMap/Secret/SyncSet resources owned by such a ClusterDeployment).
 * For each PagerDutyIntegration CR, it will get a list of matching ClusterDeployments that have the `spec.installed` field set to true.
 * For each of these ClusterDeployments, PagerDuty creates a secret which contains the integration key required to communicate with PagerDuty Web application.
-* The PagerDuty operator then creates [syncset](https://github.com/openshift/hive/blob/master/config/crds/hive_v1_syncset.yaml) with the relevant information for hive to send the PagerDuty secret to the newly provisioned cluster .
+* The PagerDuty operator then creates [syncset](https://github.com/openshift/hive/blob/master/config/crds/hive.openshift.io_syncsets.yaml) with the relevant information for hive to send the PagerDuty secret to the newly provisioned cluster .
 * This syncset is used by hive to deploy the pagerduty secret to the provisioned cluster so that the relevant SRE team get notified of alerts on the cluster.
 * The pagerduty secret is deployed to the coordinates specified in the `spec.targetSecretRef` field of the PagerDutyIntegration CR.
 

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -119,10 +119,10 @@ func NewClient(APIKey string, controllerName string) Client {
 // Data describes the data that is needed for PagerDuty api calls
 type Data struct {
 	// These fields are parsed from the PagerDutyIntegration CR
-	PDIEscalationPolicyID string
-	ResolveTimeout        uint
-	AcknowledgeTimeOut    uint
-	ServicePrefix         string
+	EscalationPolicyID string
+	ResolveTimeout     uint
+	AcknowledgeTimeOut uint
+	ServicePrefix      string
 
 	// ClusterID and BaseDomain are required during service creation for naming
 	ClusterID  string
@@ -130,11 +130,11 @@ type Data struct {
 
 	// These fields are stored when the PagerDuty service is created and stored
 	// in a Configmap in the ClusterDeployment's namespace
-	ServiceID          string
-	IntegrationID      string
-	EscalationPolicyID string
-	Hibernating        bool
-	LimitedSupport     bool
+	// There is also an EscalationPolicyID field which is parsed fron the PDI CR
+	ServiceID      string
+	IntegrationID  string
+	Hibernating    bool
+	LimitedSupport bool
 }
 
 // NewData initializes a Data struct from a v1alpha1 PagerDutyIntegration spec
@@ -145,18 +145,17 @@ func NewData(pdi *pagerdutyv1alpha1.PagerDutyIntegration, clusterId string, base
 	}
 
 	return &Data{
-		PDIEscalationPolicyID: pdi.Spec.EscalationPolicy,
-		ResolveTimeout:        pdi.Spec.ResolveTimeout,
-		AcknowledgeTimeOut:    pdi.Spec.AcknowledgeTimeout,
-		ServicePrefix:         pdi.Spec.ServicePrefix,
-		ClusterID:             clusterId,
-		BaseDomain:            baseDomain,
+		EscalationPolicyID: pdi.Spec.EscalationPolicy,
+		ResolveTimeout:     pdi.Spec.ResolveTimeout,
+		AcknowledgeTimeOut: pdi.Spec.AcknowledgeTimeout,
+		ServicePrefix:      pdi.Spec.ServicePrefix,
+		ClusterID:          clusterId,
+		BaseDomain:         baseDomain,
 	}, nil
 }
 
 // ParseClusterConfig parses the cluster specific config map and stores the IDs in the data struct
-// SERVICE_ID and INTEGRATION_ID are required ConfigMap data fields,
-// ESCALATION_POLICY_ID defaults to the PDI defined escalation policy id, and
+// SERVICE_ID and INTEGRATION_ID are required ConfigMap data fields
 // HIBERNATING and LIMITED_SUPPORT are optional.
 func (data *Data) ParseClusterConfig(osc client.Client, namespace string, cmName string) error {
 	pdAPIConfigMap := &corev1.ConfigMap{}
@@ -176,12 +175,9 @@ func (data *Data) ParseClusterConfig(osc client.Client, namespace string, cmName
 	}
 
 	data.EscalationPolicyID, err = getConfigMapKey(pdAPIConfigMap.Data, "ESCALATION_POLICY_ID")
+	// do not return error, allow EscalationPolicyID to be empty string
 	if err != nil {
-		// If data.PDIEscalationPolicyID exists, use that as a default
-		if data.PDIEscalationPolicyID == "" {
-			return err
-		}
-		data.EscalationPolicyID = data.PDIEscalationPolicyID
+		data.EscalationPolicyID = ""
 	}
 
 	val := pdAPIConfigMap.Data["HIBERNATING"]
@@ -235,7 +231,7 @@ func (c *SvcClient) GetIntegrationKey(data *Data) (string, error) {
 
 // CreateService creates a service in pagerduty for the specified clusterid and returns the service key
 func (c *SvcClient) CreateService(data *Data) (string, error) {
-	escalationPolicy, err := c.PdClient.GetEscalationPolicy(data.PDIEscalationPolicyID, nil)
+	escalationPolicy, err := c.PdClient.GetEscalationPolicy(data.EscalationPolicyID, nil)
 	if err != nil {
 		return "", errors.New("Escalation policy not found in PagerDuty")
 	}
@@ -377,7 +373,7 @@ func (c *SvcClient) DisableService(data *Data) error {
 
 // UpdateEscalationPolicy will update the PD service escalation policy
 func (c *SvcClient) UpdateEscalationPolicy(data *Data) error {
-	escalationPolicy, err := c.PdClient.GetEscalationPolicy(data.PDIEscalationPolicyID, &pdApi.GetEscalationPolicyOptions{})
+	escalationPolicy, err := c.PdClient.GetEscalationPolicy(data.EscalationPolicyID, &pdApi.GetEscalationPolicyOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/pagerduty/service_test.go
+++ b/pkg/pagerduty/service_test.go
@@ -163,7 +163,7 @@ func TestParseSetClusterConfig(t *testing.T) {
 		client := fake.NewFakeClientWithScheme(s, cm)
 
 		testData := Data{
-			PDIEscalationPolicyID: mockEscalationPolicyId,
+			EscalationPolicyID: mockEscalationPolicyId,
 		}
 		parseErr := testData.ParseClusterConfig(client, test.namespace, test.cmName)
 
@@ -285,19 +285,19 @@ func TestSvcClient_CreateService(t *testing.T) {
 		{
 			name: "Works",
 			data: &Data{
-				PDIEscalationPolicyID: mockEscalationPolicyId,
-				ResolveTimeout:        30,
-				AcknowledgeTimeOut:    30,
-				ServicePrefix:         "servicePrefix",
-				ClusterID:             "clusterID",
-				BaseDomain:            "baseDomain",
+				EscalationPolicyID: mockEscalationPolicyId,
+				ResolveTimeout:     30,
+				AcknowledgeTimeOut: 30,
+				ServicePrefix:      "servicePrefix",
+				ClusterID:          "clusterID",
+				BaseDomain:         "baseDomain",
 			},
 			expectErr: false,
 		},
 		{
 			name: "Can't find escalation policy",
 			data: &Data{
-				PDIEscalationPolicyID: "notfound",
+				EscalationPolicyID: "notfound",
 			},
 			expectErr: true,
 		},
@@ -360,23 +360,23 @@ func TestSvcClient_UpdateEscalationPolicy(t *testing.T) {
 		{
 			name: "normal",
 			data: &Data{
-				PDIEscalationPolicyID: mockEscalationPolicyId2,
-				ServiceID:             mockServiceId,
+				EscalationPolicyID: mockEscalationPolicyId2,
+				ServiceID:          mockServiceId,
 			},
 			expectErr: false,
 		},
 		{
 			name: "missing escalation policy",
 			data: &Data{
-				PDIEscalationPolicyID: "notfound",
+				EscalationPolicyID: "notfound",
 			},
 			expectErr: true,
 		},
 		{
 			name: "missing service",
 			data: &Data{
-				PDIEscalationPolicyID: mockEscalationPolicyId,
-				ServiceID:             "notfound",
+				EscalationPolicyID: mockEscalationPolicyId,
+				ServiceID:          "notfound",
 			},
 			expectErr: true,
 		},


### PR DESCRIPTION
Relates to: [OSD-12385](https://issues.redhat.com/browse/OSD-12385)
<hr>

- Currently, for existing PagerDuty services, the PD ConfigMaps do not have the `EscalationPolicyID` data field. Only the newly created service ConfigMaps have it.
- This is necessary to detect when there is a change in the PagerDutyIntegration escalation policy, compare it with the existing ConfigMap escalation policy, update the service and reconcile.

#### Changes with this PR
- Default to using PagerDutyIntegration CR's `EscalationPolicyID` as the source of truth for PagerDuty Operator escalation policy. This makes the `PDIEscalationPolicyID` field obsolete.
- Check if the ClusterDeployment's ConfigMap has the `ESCALATION_POLICY_ID` key, if not, map it to the PagerDutyIntegration CR `EscalationPolicyID` and update the ConfigMap. This will change the PagerDuty ConfigMap for all existing ClusterDeployments.
- Compare the ConfigMap escalation policy ID with the PDI escalation policy, if there's a change detected, update the PagerDuty service, and update the relevant ConfigMap. This is true only if the ConfigMap has the `ESCALATION_POLICY_ID` key and it is not empty.
- Implement unit tests to verify the above changes.