### PR TITLE
[OSD-11466] Addresses findings by the gosec linter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,9 @@ const (
 	OperatorConfigMapName  string = "pagerduty-config"
 	OperatorName           string = "pagerduty-operator"
 	OperatorNamespace      string = "pagerduty-operator"
-	PagerDutyAPISecretName string = "pagerduty-api-key"
-	PagerDutyAPISecretKey  string = "PAGERDUTY_API_KEY"
-	PagerDutySecretKey     string = "PAGERDUTY_KEY"
+	PagerDutyAPISecretName string = "pagerduty-api-key" // #nosec G101 -- This is a false positive
+	PagerDutyAPISecretKey  string = "PAGERDUTY_API_KEY" // #nosec G101 -- This is a false positive
+	PagerDutySecretKey     string = "PAGERDUTY_KEY"     // #nosec G101 -- This is a false positive
 	// PagerDutyFinalizerPrefix prefix used for finalizers on resources other than PDI
 	PagerDutyFinalizerPrefix string = "pd.managed.openshift.io/"
 	// PagerDutyIntegrationFinalizer name of finalizer used for PDI

--- a/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
+++ b/pkg/controller/pagerdutyintegration/pagerdutyintegration_controller.go
@@ -226,6 +226,7 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 	if pdi.DeletionTimestamp != nil {
 		if utils.HasFinalizer(pdi, config.PagerDutyIntegrationFinalizer) {
 			for _, clusterdeployment := range allClusterDeployments.Items {
+				clusterdeployment := clusterdeployment
 				if utils.HasFinalizer(&clusterdeployment, clusterDeploymentFinalizerName) {
 					err = r.handleDelete(pdClient, pdi, &clusterdeployment)
 					if err != nil {
@@ -258,6 +259,7 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 	var reconcileErrors pdiReconcileErrors
 	// Process all ClusterDeployments with the PDI finalizer for PD service deletion
 	for _, cd := range allClusterDeployments.Items {
+		cd := cd
 		if utils.HasFinalizer(&cd, clusterDeploymentFinalizerName) {
 			if cd.DeletionTimestamp != nil {
 				// The ClusterDeployment is being deleted, so delete the PD service
@@ -289,6 +291,7 @@ func (r *ReconcilePagerDutyIntegration) Reconcile(request reconcile.Request) (re
 
 	// and finally, any Matching CD not being deleted
 	for _, cd := range matchingClusterDeployments.Items {
+		cd := cd
 		if cd.DeletionTimestamp == nil {
 			if err := r.handleCreate(pdClient, pdi, &cd); err != nil {
 				reconcileErrors = append(reconcileErrors, err)

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -264,6 +264,7 @@ func (c *SvcClient) CreateService(data *Data) (string, error) {
 
 		if len(currentSvcs.Services) > 0 {
 			for _, svc := range currentSvcs.Services {
+				svc := svc
 				if svc.Name == clusterService.Name {
 					newSvc = &svc
 					break


### PR DESCRIPTION
Doing a prelim run of the gosec linter found a few issues, this PR addresses those findings and fixes them.
The ones in the config.go file were flagged as possible hard coded passwords, that is a false positive and the test has been disabled for those lines.