### PR TITLE
OSD-12437 Use upstream `UpdateService`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,11 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.57.0 // indirect
-	github.com/PagerDuty/go-pagerduty v1.5.0
+	github.com/PagerDuty/go-pagerduty v1.5.1-0.20220711135237-1c427f9a1638
 	github.com/go-logr/logr v0.2.1
 	github.com/go-openapi/spec v0.19.4
 	github.com/golang/mock v1.4.4
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.6/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
-github.com/PagerDuty/go-pagerduty v1.5.0 h1:/p8FGD32G8HGm7MQIjlTPTGXRJ62Qkm8Lmt5BcUVJOo=
-github.com/PagerDuty/go-pagerduty v1.5.0/go.mod h1:txr8VbObXdk2RkqF+C2an4qWssdGY99fK26XYUDjh+4=
+github.com/PagerDuty/go-pagerduty v1.5.1-0.20220711135237-1c427f9a1638 h1:BLj1lcGwZOndFzEHSOwGCeeJuAVDdjrlwTVw4jEWhTU=
+github.com/PagerDuty/go-pagerduty v1.5.1-0.20220711135237-1c427f9a1638/go.mod h1:7eaBLzsDpK7VUvU0SJ5mohczQkoWrrr5CjDaw5gh1as=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
@@ -399,8 +399,9 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -1087,8 +1088,9 @@ golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220406155245-289d7a0edf71 h1:PRD0hj6tTuUnCFD08vkvjkYFbQg/9lV8KIxe1y4/cvU=
+golang.org/x/sys v0.0.0-20220406155245-289d7a0edf71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/pagerduty/mock_service.go
+++ b/pkg/pagerduty/mock_service.go
@@ -5,65 +5,36 @@
 package pagerduty
 
 import (
+	reflect "reflect"
+
 	go_pagerduty "github.com/PagerDuty/go-pagerduty"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// GetService mocks base method
-func (m *MockClient) GetService(data *Data) (*go_pagerduty.Service, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetService", data)
-	ret0, _ := ret[0].(*go_pagerduty.Service)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetService indicates an expected call of GetService
-func (mr *MockClientMockRecorder) GetService(data interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockClient)(nil).GetService), data)
-}
-
-// GetIntegrationKey mocks base method
-func (m *MockClient) GetIntegrationKey(data *Data) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIntegrationKey", data)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetIntegrationKey indicates an expected call of GetIntegrationKey
-func (mr *MockClientMockRecorder) GetIntegrationKey(data interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIntegrationKey", reflect.TypeOf((*MockClient)(nil).GetIntegrationKey), data)
-}
-
-// CreateService mocks base method
+// CreateService mocks base method.
 func (m *MockClient) CreateService(data *Data) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateService", data)
@@ -72,13 +43,13 @@ func (m *MockClient) CreateService(data *Data) (string, error) {
 	return ret0, ret1
 }
 
-// CreateService indicates an expected call of CreateService
+// CreateService indicates an expected call of CreateService.
 func (mr *MockClientMockRecorder) CreateService(data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateService", reflect.TypeOf((*MockClient)(nil).CreateService), data)
 }
 
-// DeleteService mocks base method
+// DeleteService mocks base method.
 func (m *MockClient) DeleteService(data *Data) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteService", data)
@@ -86,27 +57,13 @@ func (m *MockClient) DeleteService(data *Data) error {
 	return ret0
 }
 
-// DeleteService indicates an expected call of DeleteService
+// DeleteService indicates an expected call of DeleteService.
 func (mr *MockClientMockRecorder) DeleteService(data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteService", reflect.TypeOf((*MockClient)(nil).DeleteService), data)
 }
 
-// EnableService mocks base method
-func (m *MockClient) EnableService(data *Data) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnableService", data)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// EnableService indicates an expected call of EnableService
-func (mr *MockClientMockRecorder) EnableService(data interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableService", reflect.TypeOf((*MockClient)(nil).EnableService), data)
-}
-
-// DisableService mocks base method
+// DisableService mocks base method.
 func (m *MockClient) DisableService(data *Data) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableService", data)
@@ -114,13 +71,57 @@ func (m *MockClient) DisableService(data *Data) error {
 	return ret0
 }
 
-// DisableService indicates an expected call of DisableService
+// DisableService indicates an expected call of DisableService.
 func (mr *MockClientMockRecorder) DisableService(data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableService", reflect.TypeOf((*MockClient)(nil).DisableService), data)
 }
 
-// UpdateEscalationPolicy mocks base method
+// EnableService mocks base method.
+func (m *MockClient) EnableService(data *Data) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnableService", data)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnableService indicates an expected call of EnableService.
+func (mr *MockClientMockRecorder) EnableService(data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableService", reflect.TypeOf((*MockClient)(nil).EnableService), data)
+}
+
+// GetIntegrationKey mocks base method.
+func (m *MockClient) GetIntegrationKey(data *Data) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIntegrationKey", data)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIntegrationKey indicates an expected call of GetIntegrationKey.
+func (mr *MockClientMockRecorder) GetIntegrationKey(data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIntegrationKey", reflect.TypeOf((*MockClient)(nil).GetIntegrationKey), data)
+}
+
+// GetService mocks base method.
+func (m *MockClient) GetService(data *Data) (*go_pagerduty.Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetService", data)
+	ret0, _ := ret[0].(*go_pagerduty.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetService indicates an expected call of GetService.
+func (mr *MockClientMockRecorder) GetService(data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockClient)(nil).GetService), data)
+}
+
+// UpdateEscalationPolicy mocks base method.
 func (m *MockClient) UpdateEscalationPolicy(data *Data) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateEscalationPolicy", data)
@@ -128,125 +129,36 @@ func (m *MockClient) UpdateEscalationPolicy(data *Data) error {
 	return ret0
 }
 
-// UpdateEscalationPolicy indicates an expected call of UpdateEscalationPolicy
+// UpdateEscalationPolicy indicates an expected call of UpdateEscalationPolicy.
 func (mr *MockClientMockRecorder) UpdateEscalationPolicy(data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEscalationPolicy", reflect.TypeOf((*MockClient)(nil).UpdateEscalationPolicy), data)
 }
 
-// UpdateService mocks base method
-func (m *MockClient) UpdateService(service *go_pagerduty.Service) (*go_pagerduty.Service, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateService", service)
-	ret0, _ := ret[0].(*go_pagerduty.Service)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateService indicates an expected call of UpdateService
-func (mr *MockClientMockRecorder) UpdateService(service interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateService", reflect.TypeOf((*MockClient)(nil).UpdateService), service)
-}
-
-// MockPdClient is a mock of PdClient interface
+// MockPdClient is a mock of PdClient interface.
 type MockPdClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockPdClientMockRecorder
 }
 
-// MockPdClientMockRecorder is the mock recorder for MockPdClient
+// MockPdClientMockRecorder is the mock recorder for MockPdClient.
 type MockPdClientMockRecorder struct {
 	mock *MockPdClient
 }
 
-// NewMockPdClient creates a new mock instance
+// NewMockPdClient creates a new mock instance.
 func NewMockPdClient(ctrl *gomock.Controller) *MockPdClient {
 	mock := &MockPdClient{ctrl: ctrl}
 	mock.recorder = &MockPdClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPdClient) EXPECT() *MockPdClientMockRecorder {
 	return m.recorder
 }
 
-// GetService mocks base method
-func (m *MockPdClient) GetService(arg0 string, arg1 *go_pagerduty.GetServiceOptions) (*go_pagerduty.Service, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetService", arg0, arg1)
-	ret0, _ := ret[0].(*go_pagerduty.Service)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetService indicates an expected call of GetService
-func (mr *MockPdClientMockRecorder) GetService(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockPdClient)(nil).GetService), arg0, arg1)
-}
-
-// GetEscalationPolicy mocks base method
-func (m *MockPdClient) GetEscalationPolicy(arg0 string, arg1 *go_pagerduty.GetEscalationPolicyOptions) (*go_pagerduty.EscalationPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEscalationPolicy", arg0, arg1)
-	ret0, _ := ret[0].(*go_pagerduty.EscalationPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetEscalationPolicy indicates an expected call of GetEscalationPolicy
-func (mr *MockPdClientMockRecorder) GetEscalationPolicy(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEscalationPolicy", reflect.TypeOf((*MockPdClient)(nil).GetEscalationPolicy), arg0, arg1)
-}
-
-// GetIntegration mocks base method
-func (m *MockPdClient) GetIntegration(arg0, arg1 string, arg2 go_pagerduty.GetIntegrationOptions) (*go_pagerduty.Integration, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIntegration", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*go_pagerduty.Integration)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetIntegration indicates an expected call of GetIntegration
-func (mr *MockPdClientMockRecorder) GetIntegration(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIntegration", reflect.TypeOf((*MockPdClient)(nil).GetIntegration), arg0, arg1, arg2)
-}
-
-// CreateService mocks base method
-func (m *MockPdClient) CreateService(service go_pagerduty.Service) (*go_pagerduty.Service, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateService", service)
-	ret0, _ := ret[0].(*go_pagerduty.Service)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateService indicates an expected call of CreateService
-func (mr *MockPdClientMockRecorder) CreateService(service interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateService", reflect.TypeOf((*MockPdClient)(nil).CreateService), service)
-}
-
-// DeleteService mocks base method
-func (m *MockPdClient) DeleteService(id string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteService", id)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteService indicates an expected call of DeleteService
-func (mr *MockPdClientMockRecorder) DeleteService(id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteService", reflect.TypeOf((*MockPdClient)(nil).DeleteService), id)
-}
-
-// CreateIntegration mocks base method
+// CreateIntegration mocks base method.
 func (m *MockPdClient) CreateIntegration(serviceID string, integration go_pagerduty.Integration) (*go_pagerduty.Integration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateIntegration", serviceID, integration)
@@ -255,43 +167,87 @@ func (m *MockPdClient) CreateIntegration(serviceID string, integration go_pagerd
 	return ret0, ret1
 }
 
-// CreateIntegration indicates an expected call of CreateIntegration
+// CreateIntegration indicates an expected call of CreateIntegration.
 func (mr *MockPdClientMockRecorder) CreateIntegration(serviceID, integration interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIntegration", reflect.TypeOf((*MockPdClient)(nil).CreateIntegration), serviceID, integration)
 }
 
-// ListServices mocks base method
-func (m *MockPdClient) ListServices(arg0 go_pagerduty.ListServiceOptions) (*go_pagerduty.ListServiceResponse, error) {
+// CreateService mocks base method.
+func (m *MockPdClient) CreateService(service go_pagerduty.Service) (*go_pagerduty.Service, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListServices", arg0)
-	ret0, _ := ret[0].(*go_pagerduty.ListServiceResponse)
+	ret := m.ctrl.Call(m, "CreateService", service)
+	ret0, _ := ret[0].(*go_pagerduty.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListServices indicates an expected call of ListServices
-func (mr *MockPdClientMockRecorder) ListServices(arg0 interface{}) *gomock.Call {
+// CreateService indicates an expected call of CreateService.
+func (mr *MockPdClientMockRecorder) CreateService(service interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockPdClient)(nil).ListServices), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateService", reflect.TypeOf((*MockPdClient)(nil).CreateService), service)
 }
 
-// ListIncidents mocks base method
-func (m *MockPdClient) ListIncidents(arg0 go_pagerduty.ListIncidentsOptions) (*go_pagerduty.ListIncidentsResponse, error) {
+// DeleteService mocks base method.
+func (m *MockPdClient) DeleteService(id string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListIncidents", arg0)
-	ret0, _ := ret[0].(*go_pagerduty.ListIncidentsResponse)
+	ret := m.ctrl.Call(m, "DeleteService", id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteService indicates an expected call of DeleteService.
+func (mr *MockPdClientMockRecorder) DeleteService(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteService", reflect.TypeOf((*MockPdClient)(nil).DeleteService), id)
+}
+
+// GetEscalationPolicy mocks base method.
+func (m *MockPdClient) GetEscalationPolicy(arg0 string, arg1 *go_pagerduty.GetEscalationPolicyOptions) (*go_pagerduty.EscalationPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEscalationPolicy", arg0, arg1)
+	ret0, _ := ret[0].(*go_pagerduty.EscalationPolicy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListIncidents indicates an expected call of ListIncidents
-func (mr *MockPdClientMockRecorder) ListIncidents(arg0 interface{}) *gomock.Call {
+// GetEscalationPolicy indicates an expected call of GetEscalationPolicy.
+func (mr *MockPdClientMockRecorder) GetEscalationPolicy(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIncidents", reflect.TypeOf((*MockPdClient)(nil).ListIncidents), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEscalationPolicy", reflect.TypeOf((*MockPdClient)(nil).GetEscalationPolicy), arg0, arg1)
 }
 
-// ListIncidentAlertsWithOpts mocks base method
+// GetIntegration mocks base method.
+func (m *MockPdClient) GetIntegration(arg0, arg1 string, arg2 go_pagerduty.GetIntegrationOptions) (*go_pagerduty.Integration, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIntegration", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*go_pagerduty.Integration)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIntegration indicates an expected call of GetIntegration.
+func (mr *MockPdClientMockRecorder) GetIntegration(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIntegration", reflect.TypeOf((*MockPdClient)(nil).GetIntegration), arg0, arg1, arg2)
+}
+
+// GetService mocks base method.
+func (m *MockPdClient) GetService(arg0 string, arg1 *go_pagerduty.GetServiceOptions) (*go_pagerduty.Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetService", arg0, arg1)
+	ret0, _ := ret[0].(*go_pagerduty.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetService indicates an expected call of GetService.
+func (mr *MockPdClientMockRecorder) GetService(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockPdClient)(nil).GetService), arg0, arg1)
+}
+
+// ListIncidentAlertsWithOpts mocks base method.
 func (m *MockPdClient) ListIncidentAlertsWithOpts(incidentId string, o go_pagerduty.ListIncidentAlertsOptions) (*go_pagerduty.ListAlertsResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListIncidentAlertsWithOpts", incidentId, o)
@@ -300,13 +256,43 @@ func (m *MockPdClient) ListIncidentAlertsWithOpts(incidentId string, o go_pagerd
 	return ret0, ret1
 }
 
-// ListIncidentAlertsWithOpts indicates an expected call of ListIncidentAlertsWithOpts
+// ListIncidentAlertsWithOpts indicates an expected call of ListIncidentAlertsWithOpts.
 func (mr *MockPdClientMockRecorder) ListIncidentAlertsWithOpts(incidentId, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIncidentAlertsWithOpts", reflect.TypeOf((*MockPdClient)(nil).ListIncidentAlertsWithOpts), incidentId, o)
 }
 
-// ManageEvent mocks base method
+// ListIncidents mocks base method.
+func (m *MockPdClient) ListIncidents(arg0 go_pagerduty.ListIncidentsOptions) (*go_pagerduty.ListIncidentsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListIncidents", arg0)
+	ret0, _ := ret[0].(*go_pagerduty.ListIncidentsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListIncidents indicates an expected call of ListIncidents.
+func (mr *MockPdClientMockRecorder) ListIncidents(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIncidents", reflect.TypeOf((*MockPdClient)(nil).ListIncidents), arg0)
+}
+
+// ListServices mocks base method.
+func (m *MockPdClient) ListServices(arg0 go_pagerduty.ListServiceOptions) (*go_pagerduty.ListServiceResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListServices", arg0)
+	ret0, _ := ret[0].(*go_pagerduty.ListServiceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListServices indicates an expected call of ListServices.
+func (mr *MockPdClientMockRecorder) ListServices(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockPdClient)(nil).ListServices), arg0)
+}
+
+// ManageEvent mocks base method.
 func (m *MockPdClient) ManageEvent(e *go_pagerduty.V2Event) (*go_pagerduty.V2EventResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ManageEvent", e)
@@ -315,13 +301,13 @@ func (m *MockPdClient) ManageEvent(e *go_pagerduty.V2Event) (*go_pagerduty.V2Eve
 	return ret0, ret1
 }
 
-// ManageEvent indicates an expected call of ManageEvent
+// ManageEvent indicates an expected call of ManageEvent.
 func (mr *MockPdClientMockRecorder) ManageEvent(e interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManageEvent", reflect.TypeOf((*MockPdClient)(nil).ManageEvent), e)
 }
 
-// UpdateService mocks base method
+// UpdateService mocks base method.
 func (m *MockPdClient) UpdateService(service go_pagerduty.Service) (*go_pagerduty.Service, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateService", service)
@@ -330,7 +316,7 @@ func (m *MockPdClient) UpdateService(service go_pagerduty.Service) (*go_pagerdut
 	return ret0, ret1
 }
 
-// UpdateService indicates an expected call of UpdateService
+// UpdateService indicates an expected call of UpdateService.
 func (mr *MockPdClientMockRecorder) UpdateService(service interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateService", reflect.TypeOf((*MockPdClient)(nil).UpdateService), service)

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -53,7 +53,6 @@ type Client interface {
 	EnableService(data *Data) error
 	DisableService(data *Data) error
 	UpdateEscalationPolicy(data *Data) error
-	UpdateService(service *pdApi.Service) (*pdApi.Service, error)
 }
 
 type PdClient interface {
@@ -330,24 +329,11 @@ func (c *SvcClient) EnableService(data *Data) error {
 
 	if service.Status != "active" {
 		service.Status = "active"
-		_, err = c.UpdateService(service)
+		_, err = c.PdClient.UpdateService(*service)
 		return err
 	}
 
 	return nil
-}
-
-// UpdateService is a temporary wrapper until an upstream bug is fixed
-// AlertGroupingParameters.Type incorrectly defaults to "" when unset
-// https://github.com/PagerDuty/go-pagerduty/issues/438
-func (c *SvcClient) UpdateService(service *pdApi.Service) (*pdApi.Service, error) {
-	if service.AlertGroupingParameters != nil {
-		if service.AlertGroupingParameters.Type == "" {
-			service.AlertGroupingParameters = nil
-		}
-	}
-
-	return c.PdClient.UpdateService(*service)
 }
 
 // DisableService will set the PD service disabled
@@ -367,7 +353,7 @@ func (c *SvcClient) DisableService(data *Data) error {
 
 	if service.Status != "disabled" {
 		service.Status = "disabled"
-		if _, err = c.UpdateService(service); err != nil {
+		if _, err = c.PdClient.UpdateService(*service); err != nil {
 			return err
 		}
 	}
@@ -389,7 +375,7 @@ func (c *SvcClient) UpdateEscalationPolicy(data *Data) error {
 
 	service.EscalationPolicy.ID = escalationPolicy.ID
 
-	_, err = c.UpdateService(service)
+	_, err = c.PdClient.UpdateService(*service)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`UpdateService()` previously had a bug so that we needed to implement our own workaround, however it has since been fixed in https://github.com/PagerDuty/go-pagerduty/pull/448, so removing our custom wrapper since we no longer need it!