### PR TITLE
make the service orchestration optional

### DIFF
--- a/api/v1alpha1/pagerdutyintegration_types.go
+++ b/api/v1alpha1/pagerdutyintegration_types.go
@@ -52,7 +52,7 @@ type PagerDutyIntegrationSpec struct {
 	TargetSecretRef corev1.SecretReference `json:"targetSecretRef"`
 
 	//  The status of the serviceOrchestration and the referenced configmap resource
-	ServiceOrchestration ServiceOrchestration `json:"serviceOrchestration"`
+	ServiceOrchestration ServiceOrchestration `json:"serviceOrchestration,omitempty"`
 }
 
 // ServiceOrchestration defines if the service orchestration is enabled

--- a/deploy/crds/pagerduty.openshift.io_pagerdutyintegrations.yaml
+++ b/deploy/crds/pagerduty.openshift.io_pagerdutyintegrations.yaml
@@ -203,7 +203,6 @@ spec:
             - clusterDeploymentSelector
             - escalationPolicy
             - pagerdutyApiKeySecretRef
-            - serviceOrchestration
             - servicePrefix
             - targetSecretRef
             type: object


### PR DESCRIPTION
currently, the OLM failed to deploy the new version of the operator to cluster

In csv there are errors:
```
    Group:    apiextensions.k8s.io
    Kind:     CustomResourceDefinition
    Message:  CRD installed alongside other CSV(s): pagerduty-operator.v0.1.418-7b8d16f
    Name:     pagerdutyintegrations.pagerduty.openshift.io
    Status:   PresentNotSatisfied
    Version:  v1
```

And in installplan, there are errors:
```
    message: 'error validating existing CRs against new CRD''s schema for "pagerdutyintegrations.pagerduty.openshift.io":
      error validating custom resource against new schema for PagerDutyIntegration
      pagerduty-operator/addon-managed-api-service: [].spec.serviceOrchestration:
      Required value'
```

Need to make the new field in CRD optional to pass the check.

cc @NautiluX 