### PR TITLE
set the enable service orchestration and apply orchestration rule as parallel logic

### DIFF
--- a/controllers/pagerdutyintegration/clusterdeployment_created.go
+++ b/controllers/pagerdutyintegration/clusterdeployment_created.go
@@ -94,7 +94,7 @@ func (r *PagerDutyIntegrationReconciler) handleCreate(pdclient pd.Client, pdi *p
 		r.reqLogger.Info("Creating configmap")
 
 		// save config map
-		newCM := kube.GenerateConfigMap(cd.Namespace, configMapName, pdData.ServiceID, pdData.IntegrationID, pdData.EscalationPolicyID, pdData.ServiceOrchestrationState, false, false)
+		newCM := kube.GenerateConfigMap(cd.Namespace, configMapName, pdData.ServiceID, pdData.IntegrationID, pdData.EscalationPolicyID, false, false, pdData.ServiceOrchestrationEnabled, pdData.ServiceOrchestrationRuleApplied)
 		if err = controllerutil.SetControllerReference(cd, newCM, r.Scheme); err != nil {
 			r.reqLogger.Error(err, "Error setting controller reference on configmap")
 			return err

--- a/pkg/kube/configmap.go
+++ b/pkg/kube/configmap.go
@@ -22,19 +22,20 @@ import (
 )
 
 // GenerateConfigMap returns a configmap that can be created with the oc client
-func GenerateConfigMap(namespace string, cmName string, pdServiceID, pdIntegrationID, pdEscalationPolicyID, serviceOrchestrationState string, hibernating, limitedSupport bool) *corev1.ConfigMap {
+func GenerateConfigMap(namespace string, cmName string, pdServiceID, pdIntegrationID, pdEscalationPolicyID string, hibernating, limitedSupport, serviceOrchestrationEnabled, serviceOrchestrationRuleApplied bool) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			"SERVICE_ID":            pdServiceID,
-			"INTEGRATION_ID":        pdIntegrationID,
-			"ESCALATION_POLICY_ID":  pdEscalationPolicyID,
-			"HIBERNATING":           strconv.FormatBool(hibernating),
-			"LIMITED_SUPPORT":       strconv.FormatBool(limitedSupport),
-			"SERVICE_ORCHESTRATION": serviceOrchestrationState,
+			"SERVICE_ID":                         pdServiceID,
+			"INTEGRATION_ID":                     pdIntegrationID,
+			"ESCALATION_POLICY_ID":               pdEscalationPolicyID,
+			"HIBERNATING":                        strconv.FormatBool(hibernating),
+			"LIMITED_SUPPORT":                    strconv.FormatBool(limitedSupport),
+			"SERVICE_ORCHESTRATION_ENABLED":      strconv.FormatBool(serviceOrchestrationEnabled),
+			"SERVICE_ORCHESTRATION_RULE_APPLIED": strconv.FormatBool(serviceOrchestrationRuleApplied),
 		},
 	}
 }

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -142,8 +142,9 @@ type Data struct {
 	LimitedSupport bool
 
 	// ServiceOrchestration related parameters
-	ServiceOrchestrationState string
-	ServiceOrchestrationRules string
+	ServiceOrchestrationEnabled     bool
+	ServiceOrchestrationRuleApplied bool
+	ServiceOrchestrationRules       string
 }
 
 // NewData initializes a Data struct from a v1alpha1 PagerDutyIntegration spec
@@ -195,10 +196,11 @@ func (data *Data) ParseClusterConfig(osc client.Client, namespace string, cmName
 	isInLimitedSupport := pdAPIConfigMap.Data["LIMITED_SUPPORT"]
 	data.LimitedSupport = isInLimitedSupport == "true"
 
-	data.ServiceOrchestrationState, err = getConfigMapKey(pdAPIConfigMap.Data, "SERVICE_ORCHESTRATION")
-	if err != nil {
-		data.ServiceOrchestrationState = ""
-	}
+	serviceOrchestrationEnabled := pdAPIConfigMap.Data["SERVICE_ORCHESTRATION_ENABLED"]
+	data.ServiceOrchestrationEnabled = serviceOrchestrationEnabled == "true"
+
+	serviceOrchestrationRuleApplied := pdAPIConfigMap.Data["SERVICE_ORCHESTRATION_RULE_APPLIED"]
+	data.ServiceOrchestrationRuleApplied = serviceOrchestrationRuleApplied == "true"
 
 	return nil
 }
@@ -215,7 +217,8 @@ func (data *Data) SetClusterConfig(osc client.Client, namespace string, cmName s
 	pdAPIConfigMap.Data["ESCALATION_POLICY_ID"] = data.EscalationPolicyID
 	pdAPIConfigMap.Data["HIBERNATING"] = strconv.FormatBool(data.Hibernating)
 	pdAPIConfigMap.Data["LIMITED_SUPPORT"] = strconv.FormatBool(data.LimitedSupport)
-	pdAPIConfigMap.Data["SERVICE_ORCHESTRATION"] = data.ServiceOrchestrationState
+	pdAPIConfigMap.Data["SERVICE_ORCHESTRATION_ENABLED"] = strconv.FormatBool(data.ServiceOrchestrationEnabled)
+	pdAPIConfigMap.Data["SERVICE_ORCHESTRATION_RULE_APPLIED"] = strconv.FormatBool(data.ServiceOrchestrationRuleApplied)
 
 	if err := osc.Update(context.TODO(), pdAPIConfigMap); err != nil {
 		return err


### PR DESCRIPTION
Set the `ServiceOrchetrationEnabled`(was `ServiceOrchestrationState`) and `ServiceOrchestrationRuleApplied` separately in the cluster configmap to make sure the reconcile loop could handle them separately.

There was a problem before, that it is possible the `ServiceOrchestrationState` set to `active` when the ServiceOrchestration enabled but the ServiceOrchestration rule was not applied due to it is missing at the beginning. And the reconcile loop will not apply it anymore when the rule added since the value set the `active`. It will also be an issue if we want to update the rule in future.

Separated indicator in configmap could call the `ToggleServiceOrchestration` and `ApplyServiceOrchestrationRule` in parallel. 

Also add the related tests.