### PR TITLE
OSD-13740 Specify missing template parameters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -32,7 +32,10 @@ parameters:
   required: true
 - name: FEDRAMP
   value: "false"
-
+- name: SERVICE_ORCHESTRATION_ENABLED
+  value: false
+- name: SERVICE_ORCHESTRATION_RULE_CONFIGMAP
+  value: "osd-serviceorchestration"
 objects:
 - apiVersion: operators.coreos.com/v1alpha1
   kind: CatalogSource


### PR DESCRIPTION
# What does it do

Adds `SERVICE_ORCHESTRATION_ENABLED` and `SERVICE_ORCHESTRATION_RULE_CONFIGMAP` as template parameters to the OLM Artifacts template.

# Why do we need it

#209 introduced some additional templating parameters to the olm artifacts template, but did not specify them as explicit parameters in the `parameters` section, meaning that they are not getting values injected as part of the SaaS pipeline.

Refs [OSD-13740](https://issues.redhat.com//browse/OSD-13740)