### PR TITLE
Add service orchestration configmap template

### DIFF
--- a/hack/templates/00-osd-serviceorchestration.configmap.yaml.tmpl
+++ b/hack/templates/00-osd-serviceorchestration.configmap.yaml.tmpl
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: osd-serviceorchestration-template
+parameters:
+- name: SERVICE_ORCHESTRATION_RULES
+  required: true
+- name: SERVICE_ORCHESTRATION_RULE_CONFIGMAP
+  required: true
+objects:
+- apiVersion: v1
+  data:
+    service-orchestration.json: ${SERVICE_ORCHESTRATION_RULES}
+  kind: ConfigMap
+  metadata:
+    name: ${SERVICE_ORCHESTRATION_RULE_CONFIGMAP}
+    namespace: pagerduty-operator
+    labels:
+      api.openshift.com/managed: "true"


### PR DESCRIPTION
# What

- Introduces a new template representing the pagerduty-operator's service orchestration configmap. 

# Why 

This template will be processed by app-interface to deploy the processed template onto Hive shards so that pagerduty-operator can (when enabled) perform service orchestration enablement on managed PD services.

# Questions and answers

_Why is this being introduced as a separate template rather than in the OLM template bundle?_

- I don't believe a processed template for this is a valid resource to go in the OLM catalog bundle. Including it as part of the catalog would require promoting a new release of the pagerduty operator every time we want to roll out service orchestration rule updates. Rule updates, especially if we grow them in the future, should stand independent of the operator.

_Why can this not be deployed in managed-cluster-config?_

- It could, but we lose the ability to then have unique configurations for integration, staging and production, because all Hive shards are production clusters. We can and should test out rule updates in staging before deploying them to Production.
- app-interface should always be a preferred deployment mechanism for Hive-related configurations.

# How will this work?

An associated app-interface change to pagerduty-operator's SaaS file will process the template and populate the parameters with expected values (which will be similarly managed in app-interface and can be made environment-specific in future if needed):

https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/54352

# Validation

This has been tested locally:

```
oc process --local -f 00-osd-serviceorchestration.configmap.yaml.tmpl -o yaml SERVICE_ORCHESTRATION_RULE_CONFIGMAP=osd-serviceorchestration SERVICE_ORCHESTRATION_RULES="$ruleData"
```

# Refs

[OSD-12648](https://issues.redhat.com//browse/OSD-12648)
