### PR TITLE
write service orchestration rule data to clusterconfigmap directly

### DIFF
--- a/controllers/pagerdutyintegration/event_handlers.go
+++ b/controllers/pagerdutyintegration/event_handlers.go
@@ -18,9 +18,9 @@ package pagerdutyintegration
 
 import (
 	"context"
-
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	pagerdutyv1alpha1 "github.com/openshift/pagerduty-operator/api/v1alpha1"
+	"github.com/openshift/pagerduty-operator/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -230,6 +230,12 @@ func (e *enqueueRequestForConfigMap) Generic(evt event.GenericEvent, q workqueue
 // take a look at that PagerDutyIntegration object.
 func (e *enqueueRequestForConfigMap) toRequests(obj client.Object) []reconcile.Request {
 	reqs := []reconcile.Request{}
+
+	// enqueue for configmap in the operator namespace only
+	if obj.GetNamespace() != config.OperatorNamespace {
+		return reqs
+	}
+
 	pdiList := &pagerdutyv1alpha1.PagerDutyIntegrationList{}
 	if err := e.Client.List(context.TODO(), pdiList, &client.ListOptions{}); err != nil {
 		return reqs

--- a/controllers/pagerdutyintegration/pagerdutyintegration_controller_test.go
+++ b/controllers/pagerdutyintegration/pagerdutyintegration_controller_test.go
@@ -181,7 +181,7 @@ func testServiceOrchestrationRuleConfigMap(isManaged bool) *corev1.ConfigMap {
 			},
 		},
 		Data: map[string]string{
-			"service-orchestration.json": "{}",
+			"service-orchestration.json": "{\"test-key\" : \"test-value\"}",
 		},
 	}
 }
@@ -838,7 +838,7 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 				r.GetIntegrationKey(gomock.Any()).Return(testIntegrationID, nil).Times(1)
 				r.UpdateEscalationPolicy(gomock.Any()).Return(nil).Times(0)
 				r.ToggleServiceOrchestration(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(3)
+				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(1)
 				r.DeleteService(gomock.Any()).Return(nil).Times(0)
 				r.DisableService(gomock.Any()).Return(nil).Times(0)
 				r.EnableService(gomock.Any()).Return(nil).Times(0)
@@ -860,13 +860,12 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 						data.IntegrationID = "LMN456"
 						data.EscalationPolicyID = testEscalationPolicy
 						data.ServiceOrchestrationEnabled = true
-						data.ServiceOrchestrationRuleApplied = true
 						return data.IntegrationID, nil
 					})
 				r.GetIntegrationKey(gomock.Any()).Return(testIntegrationID, nil).Times(1)
 				r.UpdateEscalationPolicy(gomock.Any()).Return(nil).Times(0)
 				r.ToggleServiceOrchestration(gomock.Any(), gomock.Any()).Return(nil).Times(0)
-				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(3)
+				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(1)
 				r.DeleteService(gomock.Any()).Return(nil).Times(0)
 				r.DisableService(gomock.Any()).Return(nil).Times(0)
 				r.EnableService(gomock.Any()).Return(nil).Times(0)
@@ -893,7 +892,7 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 				r.GetIntegrationKey(gomock.Any()).Return(testIntegrationID, nil).Times(1)
 				r.UpdateEscalationPolicy(gomock.Any()).Return(nil).Times(0)
 				r.ToggleServiceOrchestration(gomock.Any(), gomock.Any()).Return(nil).Times(0)
-				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(3)
+				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(1)
 				r.DeleteService(gomock.Any()).Return(nil).Times(0)
 				r.DisableService(gomock.Any()).Return(nil).Times(0)
 				r.EnableService(gomock.Any()).Return(nil).Times(0)
@@ -914,13 +913,12 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 						data.ServiceID = "XYZ123"
 						data.IntegrationID = "LMN456"
 						data.EscalationPolicyID = testEscalationPolicy
-						data.ServiceOrchestrationRuleApplied = true
 						return data.IntegrationID, nil
 					})
 				r.GetIntegrationKey(gomock.Any()).Return(testIntegrationID, nil).Times(1)
 				r.UpdateEscalationPolicy(gomock.Any()).Return(nil).Times(0)
 				r.ToggleServiceOrchestration(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(3)
+				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(1)
 				r.DeleteService(gomock.Any()).Return(nil).Times(0)
 				r.DisableService(gomock.Any()).Return(nil).Times(0)
 				r.EnableService(gomock.Any()).Return(nil).Times(0)
@@ -946,7 +944,7 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 				r.GetIntegrationKey(gomock.Any()).Return(testIntegrationID, nil).Times(1)
 				r.UpdateEscalationPolicy(gomock.Any()).Return(nil).Times(0)
 				r.ToggleServiceOrchestration(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(3)
+				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(1)
 				r.DeleteService(gomock.Any()).Return(nil).Times(0)
 				r.DisableService(gomock.Any()).Return(nil).Times(0)
 				r.EnableService(gomock.Any()).Return(nil).Times(0)
@@ -972,7 +970,7 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 				r.GetIntegrationKey(gomock.Any()).Return(testIntegrationID, nil).Times(1)
 				r.UpdateEscalationPolicy(gomock.Any()).Return(nil).Times(0)
 				r.ToggleServiceOrchestration(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(0)
+				r.ApplyServiceOrchestrationRule(gomock.Any()).Return(nil).Times(1)
 				r.DeleteService(gomock.Any()).Return(nil).Times(0)
 				r.DisableService(gomock.Any()).Return(nil).Times(0)
 				r.EnableService(gomock.Any()).Return(nil).Times(0)

--- a/pkg/kube/configmap.go
+++ b/pkg/kube/configmap.go
@@ -22,7 +22,7 @@ import (
 )
 
 // GenerateConfigMap returns a configmap that can be created with the oc client
-func GenerateConfigMap(namespace string, cmName string, pdServiceID, pdIntegrationID, pdEscalationPolicyID string, hibernating, limitedSupport, serviceOrchestrationEnabled, serviceOrchestrationRuleApplied bool) *corev1.ConfigMap {
+func GenerateConfigMap(namespace string, cmName string, pdServiceID, pdIntegrationID, pdEscalationPolicyID string, hibernating, limitedSupport, serviceOrchestrationEnabled bool, serviceOrchestrationRuleApplied string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
@@ -35,7 +35,7 @@ func GenerateConfigMap(namespace string, cmName string, pdServiceID, pdIntegrati
 			"HIBERNATING":                        strconv.FormatBool(hibernating),
 			"LIMITED_SUPPORT":                    strconv.FormatBool(limitedSupport),
 			"SERVICE_ORCHESTRATION_ENABLED":      strconv.FormatBool(serviceOrchestrationEnabled),
-			"SERVICE_ORCHESTRATION_RULE_APPLIED": strconv.FormatBool(serviceOrchestrationRuleApplied),
+			"SERVICE_ORCHESTRATION_RULE_APPLIED": serviceOrchestrationRuleApplied,
 		},
 	}
 }


### PR DESCRIPTION
write the contents of the service orchestration rule to the clusterconfigmap

so that, we can skip the `ApplyServiceOrchestrationRule()` call if it has been applied already.

The logic will be:

- Read the `serviceorchestrationconfigmap` for pagerduty-operator to configure the service orchestration
- Read the `clusterconfigmap` which includes the applied orchestration rule
- Apply if value in `clusterconfigmap` does not match the `serviceorchestrationconfigmap`
- Update the `clusterconfigmap` after apply
