### PR TITLE
Add more context to errors with pagerduty client interaction

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift/pagerduty-operator/controllers/pagerdutyintegration"
 	"github.com/openshift/pagerduty-operator/pkg/localmetrics"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -77,6 +78,9 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: false,
+		TimeEncoder: zapcore.RFC3339TimeEncoder,
+		// Remove misleading controller-runtime stack traces https://github.com/kubernetes-sigs/kubebuilder/issues/1593
+		StacktraceLevel: zapcore.DPanicLevel,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
# What it does
- Wraps errors stemming from pagerduty-client interactions with more context regarding what action was caused to trigger the error.
- Log timestamps in human-readable form rather than epoch seconds (took inspiration from [this](https://github.com/openshift/cloud-ingress-operator/pull/280) PR)

# Why
The errors returned from the pagerduty client library rarely give any context as to what API interaction took place. This makes it confusing or misleading when reviewing PDO logs to understand why an error is occurring. This PR wraps each error with additional context surrounding the call so that when it is passed up the chain there is a clearer picture of why the failure is occurring.

# Refs

[OSD-14350](https://issues.redhat.com//browse/OSD-14350)
