### PR TITLE
OSD-16066 alert grouping

### DIFF
--- a/controllers/pagerdutyintegration/clusterdeployment_created.go
+++ b/controllers/pagerdutyintegration/clusterdeployment_created.go
@@ -16,6 +16,7 @@ package pagerdutyintegration
 
 import (
 	"context"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
@@ -94,7 +95,7 @@ func (r *PagerDutyIntegrationReconciler) handleCreate(pdclient pd.Client, pdi *p
 		r.reqLogger.Info("Creating configmap")
 
 		// save config map
-		newCM := kube.GenerateConfigMap(cd.Namespace, configMapName, pdData.ServiceID, pdData.IntegrationID, pdData.EscalationPolicyID, false, false, pdData.ServiceOrchestrationEnabled, pdData.ServiceOrchestrationRuleApplied)
+		newCM := kube.GenerateConfigMap(cd.Namespace, configMapName, pdData.ServiceID, pdData.IntegrationID, pdData.EscalationPolicyID, false, false, pdData.ServiceOrchestrationEnabled, pdData.ServiceOrchestrationRuleApplied, pdData.AlertGroupingType, pdData.AlertGroupingTimeout)
 		if err = controllerutil.SetControllerReference(cd, newCM, r.Scheme); err != nil {
 			r.reqLogger.Error(err, "Error setting controller reference on configmap")
 			return err

--- a/pkg/kube/configmap.go
+++ b/pkg/kube/configmap.go
@@ -15,6 +15,7 @@
 package kube
 
 import (
+	"fmt"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -22,7 +23,7 @@ import (
 )
 
 // GenerateConfigMap returns a configmap that can be created with the oc client
-func GenerateConfigMap(namespace string, cmName string, pdServiceID, pdIntegrationID, pdEscalationPolicyID string, hibernating, limitedSupport, serviceOrchestrationEnabled bool, serviceOrchestrationRuleApplied string) *corev1.ConfigMap {
+func GenerateConfigMap(namespace string, cmName string, pdServiceID, pdIntegrationID, pdEscalationPolicyID string, hibernating, limitedSupport, serviceOrchestrationEnabled bool, serviceOrchestrationRuleApplied, alertGroupingType string, alertGroupingTimeout uint) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
@@ -36,6 +37,8 @@ func GenerateConfigMap(namespace string, cmName string, pdServiceID, pdIntegrati
 			"LIMITED_SUPPORT":                    strconv.FormatBool(limitedSupport),
 			"SERVICE_ORCHESTRATION_ENABLED":      strconv.FormatBool(serviceOrchestrationEnabled),
 			"SERVICE_ORCHESTRATION_RULE_APPLIED": serviceOrchestrationRuleApplied,
+			"ALERT_GROUPING_TYPE":                alertGroupingType,
+			"ALERT_GROUPING_TIMEOUT":             fmt.Sprintf("%d", alertGroupingTimeout),
 		},
 	}
 }

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -215,17 +215,19 @@ func (data *Data) ParseClusterConfig(osc client.Client, namespace string, cmName
 	}
 
 	// allow alert grouping values not to be defined in the configmap
-	data.AlertGroupingType, _ = getConfigMapKey(pdAPIConfigMap.Data, "ALERT_GROUPING_TYPE")
+	// only assign them into the struct if they're present, to avoid zero-setting them
+	alertGroupingType, err := getConfigMapKey(pdAPIConfigMap.Data, "ALERT_GROUPING_TYPE")
+	if err == nil {
+		data.AlertGroupingType = alertGroupingType
+	}
 	agto, err := getConfigMapKey(pdAPIConfigMap.Data, "ALERT_GROUPING_TIMEOUT")
-	if err != nil {
-		// if the alert grouping timeout isn't set in the configmap, default to 0
-		agto = "0"
+	if err == nil {
+		agtou64, err := strconv.ParseUint(agto, 10, 64)
+		if err != nil {
+			return err
+		}
+		data.AlertGroupingTimeout = uint(agtou64)
 	}
-	agtou64, err := strconv.ParseUint(agto, 10, 64)
-	if err != nil {
-		return err
-	}
-	data.AlertGroupingTimeout = uint(agtou64)
 
 	return nil
 }


### PR DESCRIPTION
avoid zero-setting alert grouping when parsing cluster config

If the alert grouping parameters aren't in the cluster config, do not
assign anything to the pdData variable because it will zero-set those
values and overwrite the parameters defined by the pagerdutyintegration