### PR TITLE
OSD-16066 Ensure alert grouping gets applied to existing clusters

### DIFF
--- a/controllers/pagerdutyintegration/handleupdate.go
+++ b/controllers/pagerdutyintegration/handleupdate.go
@@ -59,7 +59,10 @@ func (r *PagerDutyIntegrationReconciler) handleUpdate(pdclient pd.Client, pdi *p
 
 		cm.Data["ALERT_GROUPING_TYPE"] = pdi.Spec.AlertGroupingParameters.Type
 		cm.Data["ALERT_GROUPING_TIMEOUT"] = fmt.Sprintf("%d", pdi.Spec.AlertGroupingParameters.Config.Timeout)
-		r.Client.Update(context.TODO(), cm)
+		err = r.Client.Update(context.TODO(), cm)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/controllers/pagerdutyintegration/pagerdutyintegration_controller.go
+++ b/controllers/pagerdutyintegration/pagerdutyintegration_controller.go
@@ -212,21 +212,10 @@ func (r *PagerDutyIntegrationReconciler) Reconcile(ctx context.Context, req ctrl
 				reconcileErrors = append(reconcileErrors, err)
 			}
 
-			if pdi.Spec.AlertGroupingParameters != nil {
-				pdData, err := pd.NewData(pdi, cd.Spec.ClusterMetadata.ClusterID, cd.Spec.BaseDomain)
-				if err != nil {
-					reconcileErrors = append(reconcileErrors, err)
-				}
-				err = pdData.ParseClusterConfig(r.Client, cd.ObjectMeta.Namespace, config.Name(pdi.Spec.ServicePrefix, cd.Name, config.ConfigMapSuffix))
-				if err != nil {
-					reconcileErrors = append(reconcileErrors, err)
-				}
-				if pdData.AlertGroupingType != pdi.Spec.AlertGroupingParameters.Type || pdData.AlertGroupingTimeout != pdi.Spec.AlertGroupingParameters.Config.Timeout {
-					err = r.handleUpdate(pdClient, pdi, &cd)
-					if err != nil {
-						reconcileErrors = append(reconcileErrors, err)
-					}
-				}
+			// update alert grouping if necessary
+			err = r.handleUpdate(pdClient, pdi, &cd)
+			if err != nil {
+				reconcileErrors = append(reconcileErrors, err)
 			}
 
 			// Do nothing if the orchestration is not enabled and leave it as default for now


### PR DESCRIPTION
This updates the `handleUpdate()` function (and section of the reconcile loop where it's called) to ensure that existing clusters have alert grouping enabled when configured via a pagerdutyintegration. There are unit tests for the reconcile loop that should confirm this behavior