### PR TITLE
Prefer scheduling registry pod onto infra nodes

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -49,6 +49,12 @@ objects:
     sourceType: grpc
     grpcPodConfig:
       securityContextConfig: restricted
+      nodeSelector:
+        node-role.kubernetes.io: infra
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
     image: ${REPO_DIGEST}
     displayName: pagerduty-operator Registry
     publisher: SRE


### PR DESCRIPTION
This commit specifies .spec.grpcPodConfig.nodeSelector and .spec.grpdPodConfig.tolerations to schedule this operator's registry pod to infra nodes when possible.

[OSD-6629](https://issues.redhat.com//browse/OSD-6629)