### PR TITLE
feat: allow a separate event orchestration for RH infra clusters

### DIFF
--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/pagerdutyintegration/serviceorchestration_handler.go
+++ b/controllers/pagerdutyintegration/serviceorchestration_handler.go
@@ -3,6 +3,8 @@ package pagerdutyintegration
 import (
 	"context"
 	"fmt"
+	"reflect"
+
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	pagerdutyv1alpha1 "github.com/openshift/pagerduty-operator/api/v1alpha1"
 	"github.com/openshift/pagerduty-operator/config"
@@ -12,11 +14,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 )
 
 const (
-	ServiceOrchestrationDataName = "service-orchestration.json"
+	StandardServiceOrchestrationDataName    = "service-orchestration.json"
+	RedHatInfraServiceOrchestrationDataName = "rh-infra-service-orchestration.json"
 )
 
 // handleServiceOrchestration enables and applies the service orchestration rule to the PD service if it is enabled in PDI
@@ -96,14 +98,31 @@ func (r *PagerDutyIntegrationReconciler) handleServiceOrchestration(pdclient pd.
 		Namespace: pdi.Spec.ServiceOrchestration.RuleConfigConfigMapRef.Namespace,
 	}
 
-	orchestrationRuleConfigData, err := utils.LoadConfigMapData(r.Client,
-		serviceOrchestrationConfigMap, ServiceOrchestrationDataName)
-	if errors.IsNotFound(err) {
-		r.reqLogger.Info("service orchestration configmap rule not found, skip the following steps")
-		localmetrics.UpdateMetricPagerDutyServiceOrchestrationFailure(1, pdi.Name)
-		return nil
-	} else if err != nil {
-		return err
+	orchestrationRuleConfigData := ""
+
+	if utils.IsRedHatHyperShiftInfrastructure(cd) {
+		orchestrationRuleConfigData, err = utils.LoadConfigMapData(r.Client,
+			serviceOrchestrationConfigMap, RedHatInfraServiceOrchestrationDataName)
+
+		if errors.IsNotFound(err) {
+			r.reqLogger.Info(fmt.Sprintf("found no service orchestration configmap rule for '%s', skipping next steps", RedHatInfraServiceOrchestrationDataName))
+			localmetrics.UpdateMetricPagerDutyServiceOrchestrationFailure(1, pdi.Name)
+			return nil
+		} else if err != nil {
+			return err
+		}
+	} else {
+		orchestrationRuleConfigData, err = utils.LoadConfigMapData(r.Client,
+			serviceOrchestrationConfigMap, StandardServiceOrchestrationDataName)
+
+		if errors.IsNotFound(err) {
+			r.reqLogger.Info(fmt.Sprintf("found no service orchestration configmap rule for '%s', skipping next steps", StandardServiceOrchestrationDataName))
+			localmetrics.UpdateMetricPagerDutyServiceOrchestrationFailure(1, pdi.Name)
+			return nil
+		} else if err != nil {
+			return err
+		}
+
 	}
 
 	if pdData.ServiceOrchestrationRuleApplied != orchestrationRuleConfigData {

--- a/controllers/pagerdutyintegration/serviceorchestration_handler.go
+++ b/controllers/pagerdutyintegration/serviceorchestration_handler.go
@@ -100,7 +100,7 @@ func (r *PagerDutyIntegrationReconciler) handleServiceOrchestration(pdclient pd.
 
 	orchestrationRuleConfigData := ""
 
-	if utils.IsRedHatHyperShiftInfrastructure(cd) {
+	if utils.IsRedHatInfrastructure(cd) {
 		orchestrationRuleConfigData, err = utils.LoadConfigMapData(r.Client,
 			serviceOrchestrationConfigMap, RedHatInfraServiceOrchestrationDataName)
 

--- a/hack/templates/00-osd-serviceorchestration.configmap.yaml.tmpl
+++ b/hack/templates/00-osd-serviceorchestration.configmap.yaml.tmpl
@@ -11,6 +11,7 @@ objects:
 - apiVersion: v1
   data:
     service-orchestration.json: ${SERVICE_ORCHESTRATION_RULES}
+    rh-infra-service-orchestration.json: ${RH_INFRA_SERVICE_ORCHESTRATION_RULES}
   kind: ConfigMap
   metadata:
     name: ${SERVICE_ORCHESTRATION_RULE_CONFIGMAP}

--- a/hack/templates/00-osd-serviceorchestration.configmap.yaml.tmpl
+++ b/hack/templates/00-osd-serviceorchestration.configmap.yaml.tmpl
@@ -5,6 +5,8 @@ metadata:
 parameters:
 - name: SERVICE_ORCHESTRATION_RULES
   required: true
+- name: RH_INFRA_SERVICE_ORCHESTRATION_RULES
+  required: true
 - name: SERVICE_ORCHESTRATION_RULE_CONFIGMAP
   required: true
 objects:

--- a/pkg/pagerduty/service_mock.go
+++ b/pkg/pagerduty/service_mock.go
@@ -8,9 +8,11 @@ package pagerduty
 import (
 	"encoding/json"
 	"fmt"
-	pd "github.com/PagerDuty/go-pagerduty"
 	"net/http"
 	"net/http/httptest"
+
+	pd "github.com/PagerDuty/go-pagerduty"
+	"github.com/openshift/pagerduty-operator/pkg/utils"
 )
 
 const (
@@ -490,7 +492,7 @@ func processListIncidentAlertsQueryParams(queries map[string][]string, alerts ma
 	}
 
 	for _, alert := range alerts["alerts"] {
-		if contains(statuses, alert.Status) {
+		if utils.Contains(statuses, alert.Status) {
 			filteredAlerts["alerts"] = append(filteredAlerts["alerts"], alert)
 		}
 	}
@@ -513,21 +515,10 @@ func processListIncidentsQueryParams(queries map[string][]string, incidents map[
 	}
 
 	for _, inc := range incidents["incidents"] {
-		if contains(serviceIds, inc.Service.ID) && contains(statuses, inc.Status) {
+		if utils.Contains(serviceIds, inc.Service.ID) && utils.Contains(statuses, inc.Status) {
 			filteredIncidents["incidents"] = append(filteredIncidents["incidents"], inc)
 		}
 	}
 
 	return filteredIncidents
-}
-
-// contains returns true if a slice contains a string, otherwise false
-func contains(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -142,8 +142,8 @@ func GetClusterID(cd *hivev1.ClusterDeployment) string {
 	}
 }
 
-// IsRedHatHyperShiftInfrastructure returns whether or not a cluster is part of the Red Hat HyperShift infrastructure
-func IsRedHatHyperShiftInfrastructure(cd *hivev1.ClusterDeployment) bool {
+// IsRedHatInfrastructure returns whether or not a cluster is part of the Red Hat infrastructure
+func IsRedHatInfrastructure(cd *hivev1.ClusterDeployment) bool {
 	// hypershiftClusterTypeLabel is the annotation key for the hypershift cluster type
 	hypershiftClusterTypeLabel := "ext-hypershift.openshift.io/cluster-type"
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -141,3 +141,31 @@ func GetClusterID(cd *hivev1.ClusterDeployment) string {
 		return cd.Spec.ClusterName
 	}
 }
+
+// IsRedHatHyperShiftInfrastructure returns whether or not a cluster is part of the Red Hat HyperShift infrastructure
+func IsRedHatHyperShiftInfrastructure(cd *hivev1.ClusterDeployment) bool {
+	// hypershiftClusterTypeLabel is the annotation key for the hypershift cluster type
+	hypershiftClusterTypeLabel := "ext-hypershift.openshift.io/cluster-type"
+
+	// hypershiftInfrastructureClusterTypes are the values of the hypershiftClusterTypeLabel key
+	// that represent critical Red Hat infrastructure clusters
+	hypershiftInfrastructureClusterTypes := []string{"service-cluster", "management-cluster"}
+
+	val, ok := cd.Labels[hypershiftClusterTypeLabel]
+	if ok && Contains(hypershiftInfrastructureClusterTypes, val) {
+		return true
+	}
+
+	return false
+}
+
+// Contains returns true if a slice contains a string, otherwise false
+func Contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -144,15 +144,11 @@ func GetClusterID(cd *hivev1.ClusterDeployment) string {
 
 // IsRedHatInfrastructure returns whether or not a cluster is part of the Red Hat infrastructure
 func IsRedHatInfrastructure(cd *hivev1.ClusterDeployment) bool {
-	// hypershiftClusterTypeLabel is the annotation key for the hypershift cluster type
-	hypershiftClusterTypeLabel := "ext-hypershift.openshift.io/cluster-type"
+	// clusterRHInfraLabel is the annotation key for Red Hat infrastructure clusters
+	clusterRHInfraLabel := "ext-pagerduty.openshift.io/rh-infra"
 
-	// hypershiftInfrastructureClusterTypes are the values of the hypershiftClusterTypeLabel key
-	// that represent critical Red Hat infrastructure clusters
-	hypershiftInfrastructureClusterTypes := []string{"service-cluster", "management-cluster"}
-
-	val, ok := cd.Labels[hypershiftClusterTypeLabel]
-	if ok && Contains(hypershiftInfrastructureClusterTypes, val) {
+	val, ok := cd.Labels[clusterRHInfraLabel]
+	if ok && val == "true" {
 		return true
 	}
 


### PR DESCRIPTION
This PR is a requirement for https://issues.redhat.com/browse/OSD-17861 - after merging this, we will need to update `app-interface` with the according `rh-infra-service-orchestration.json`

**What?**

This PR enables us to pass a second event orchestration configuration that will be applied to Red Hat infrastructure clusters (currently targets hypershift SC and MC). 

**Why?**

We want to be able to react to infrastructure cluster alerts before other alerts, so that we can fix issues that possibly impact a large number of other clusters quickly. For this, we need to be able to customize infrastructure cluster alerts, which can be done using the following event orchestration configuration applied to only infrastructure clusters:

```
  rh-infra-service-orchestration.json: |
    {
    "orchestration_path": {
    "catch_all": {
        "actions": {}
    },
    "sets": [
      {
        "id": "start",
        "rules": [
          {
            "actions": {
              "suppress": true
            },
            "conditions": [
              {
                "expression": "event.severity matches 'Warning'"
              }
            ]
          },
          {
            "actions": {
              "priority": "PQF279U"
            },
            "conditions": []
          }
        ]
      }
    ],
        "type": "service"
    }
    }
```

Resulting alerts will have a priority tag:
![image](https://github.com/openshift/pagerduty-operator/assets/29230116/cf09ed21-021c-427a-a634-c1638d238f0b)

**Tested using CRC and a trial PD account:**
- PD Operator behaves as expected for standard clusters
- PD Operator applies `rh-infra-service-orchestration.json` for MCs and SCs.

Note: I will open up a follow-up PR to update the README for CRC and fix some outdated guidance.


