### PR TITLE
OSD-17913: Update logging for service updates to reflect what is being updated

### DIFF
--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -386,7 +386,7 @@ func (c *SvcClient) EnableService(data *Data) error {
 		service.Status = "active"
 		_, err = c.PdClient.UpdateService(*service)
 		if err != nil {
-			return fmt.Errorf("unable to update service ID %v: %w", data.ServiceID, err)
+			return fmt.Errorf("failed to enable service: unable to update service ID %v: %w", data.ServiceID, err)
 		}
 	}
 
@@ -411,7 +411,7 @@ func (c *SvcClient) DisableService(data *Data) error {
 	if service.Status != "disabled" {
 		service.Status = "disabled"
 		if _, err = c.PdClient.UpdateService(*service); err != nil {
-			return fmt.Errorf("unable to update service ID %v: %w", data.ServiceID, err)
+			return fmt.Errorf("failed to disable service: unable to update service ID %v: %w", data.ServiceID, err)
 		}
 	}
 
@@ -484,7 +484,7 @@ func (c *SvcClient) UpdateEscalationPolicy(data *Data) error {
 
 	_, err = c.PdClient.UpdateService(*service)
 	if err != nil {
-		return fmt.Errorf("unable to update service %v: %w", data.ServiceID, err)
+		return fmt.Errorf("failed to update escalation policy: unable to update service %v: %w", data.ServiceID, err)
 	}
 
 	return nil
@@ -506,7 +506,7 @@ func (c *SvcClient) UpdateAlertGrouping(data *Data) error {
 
 	_, err = c.PdClient.UpdateService(*service)
 	if err != nil {
-		return fmt.Errorf("unable to update service %v: %w", data.ServiceID, err)
+		return fmt.Errorf("failed to update alert grouping: unable to update service %v: %w", data.ServiceID, err)
 	}
 
 	return nil


### PR DESCRIPTION
**Why?**
The current logging for `UpdateService` does not enable us to trace back what updating failed.

**What?**
Add context to failed `UpdateService` calls

Fixes https://issues.redhat.com/browse/OSD-17913