### PR TITLE
[WIP] fix: time grouping works for all services

### DIFF
--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -497,12 +497,9 @@ func (c *SvcClient) UpdateAlertGrouping(data *Data) error {
 		return fmt.Errorf("unable to get service with ID %v: %w", data.ServiceID, err)
 	}
 
-	service.AlertGroupingParameters = &pdApi.AlertGroupingParameters{
-		Type: data.AlertGroupingType,
-		Config: &pdApi.AlertGroupParamsConfig{
-			Timeout: data.AlertGroupingTimeout,
-		},
-	}
+	// According to https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIwMA-update-a-service
+	service.AlertGrouping = "time"
+	service.AlertGroupingTimeout = &data.AlertGroupingTimeout
 
 	_, err = c.PdClient.UpdateService(*service)
 	if err != nil {


### PR DESCRIPTION
**Why?**
I noticed that on staging, adding the time based grouping fails for all management cluster and service clusters. 
On production the time based grouping fails for some random services. 
I wasn't able to figure out what causes this yet. I was able to 100% reproduce the issue with a new pagerduty account though.

```
{"level":"error","ts":"2023-08-14T08:08:57Z","msg":"Reconciler error","controller":"pagerdutyintegration","controllerGroup":"pagerduty.openshift.io","controllerKind":"PagerDutyIntegration","PagerDutyIntegration":{"name":"osd","namespace":"pagerduty-operator"},"namespace":"pagerduty-operator","name":"osd","reconcileID":"<removed>","error":"unable to update service <snip>: HTTP response failed with status code 400, message: Invalid Input Provided (code: 2001): Config is invalid. - 1 other errors"}
```

**What?**
This PR updates our `UpdateAlertGrouping` to use the parameters more precisely documented in the [official developer API ](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIwMA-update-a-service) instead of using `AlertGroupingParameters`.
`AlertGroupingParameters` is also documented in the official API, but the implementation in the pagerduty go sdk does not seem to match the latest documentation, therefore, I suggest we move away from it. 

PR is tested to properly create the event grouping for services that didn't work before. 