### PR TITLE
fix(OSD-15493): service orchestrations not setup correctly for some PD services

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 
 ENV USER_UID=1001 \
     USER_NAME=pagerduty-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/pagerdutyintegration/serviceorchestration_handler.go
+++ b/controllers/pagerdutyintegration/serviceorchestration_handler.go
@@ -128,7 +128,6 @@ func (r *PagerDutyIntegrationReconciler) handleServiceOrchestration(pdclient pd.
 	if pdData.ServiceOrchestrationRuleApplied != orchestrationRuleConfigData {
 		// Apply rule for new service
 		pdData.ServiceOrchestrationRuleApplied = orchestrationRuleConfigData
-
 		r.reqLogger.Info(fmt.Sprintf("applying the service orchestration rules from configmap: %s",
 			orchestrationConfigmapName))
 		err = pdclient.ApplyServiceOrchestrationRule(pdData)


### PR DESCRIPTION
Sometimes, PDO does not correctly apply the service orchestration (filtering out warning alerts) to a service. 

**The issue:** PDO does not query the service orchestration data from PD, instead it caches the "applied" data for every service in a configmap. This cache is inconsistent due to a bug.

**The bug:** the cached data was inconsistent with the actual applied pagerduty data, as we don't properly check if a HTTP request succeeds (documentation of `http.DefaultClient.Do)` :
```
An error is returned if caused by client policy (such as CheckRedirect), or failure to speak HTTP (such as a network connectivity problem). A non-2xx status code doesn't cause an error.
```

We only check if an error occurs, but don't check the returned status code of the http request.

**The fix:** we only update the configmap if the HTTP request properly succeeds (2xx code).

https://issues.redhat.com/browse/OSD-15493
