### PR TITLE
When disabling a service always resolve with the limited support message

### DIFF
--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -390,13 +390,8 @@ func (c *SvcClient) DisableService(data *Data) error {
 	if err != nil {
 		return fmt.Errorf("unable to get service with ID %v: %w", data.ServiceID, err)
 	}
-	summary := AlertResolvedSummaryDeleted
 
-	if data.LimitedSupport {
-		summary = AlertResolvedSummaryLimitedSupport
-	}
-
-	if err := c.resolvePendingIncidents(data, summary); err != nil {
+	if err := c.resolvePendingIncidents(data, AlertResolvedSummaryLimitedSupport); err != nil {
 		return fmt.Errorf("unable to resolve pending incidents for service ID %v: %w", data.ServiceID, err)
 	}
 


### PR DESCRIPTION
To address an error with a race condition on the limited support status from the perspective of the service. For [OSD-18059](https://issues.redhat.com//browse/OSD-18059)