### PR TITLE
Add FLs and TLs as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
 - wshearn
 - mjlshen
 - typeid
+- srep-functional-leads
 - srep-team-leads
 maintainers:
 - mjlshen


### PR DESCRIPTION
Make FLs and TLs approvers for cases where standard approvers aren't suitable/are hard to reach.

Ref [OSD-25197](https://issues.redhat.com//browse/OSD-25197)