### PR TITLE
OSD-26236 leaver process member removal

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,10 @@
 reviewers:
 - wshearn
-- mjlshen
 - bmeng
 - typeid
 - srep-team-leads
 approvers:
 - wshearn
-- mjlshen
 - typeid
 - srep-team-leads
 maintainers:
-- mjlshen

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -65,7 +65,6 @@ aliases:
     - Nikokolas3270
     - theautoroboto
     - bmeng
-    - mjlshen
     - sam-nguyen7
     - ravitri
   srep-team-leads:


### PR DESCRIPTION
Removing michael shen from OWNER_ALIAS FILE as part of the leaver process