### PR TITLE
OSD-28159 - Enable OLM Skip Range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,7 @@ const (
 	LegacyPagerDutyFinalizer string = "pd.managed.openshift.io/pagerduty"
 	SecretSuffix             string = "-pd-secret"
 	ConfigMapSuffix          string = "-pd-config"
-
+	EnableOLMSkipRange              = "true"
 	// PagerDutyUrgencyRule is the type of IncidentUrgencyRule for new incidents
 	// coming into the Service. This is for the creation of NEW SERVICES ONLY
 	// Supported values (by this operator) are:


### PR DESCRIPTION
Configure boilerplate to generate an OLM bundle with a skip range pointing to the latest version. This will allow OLM to upgrade past broken replaces chains in which versions get abadoned without a path forward. The new OLM bundle will contain a single version, referencing the latest build with a skipRange to the version. Part of [OSD-28159](https://issues.redhat.com//browse/OSD-28159) ticket.