### PR TITLE
SREP-2442: Add distribution of CAD int key via PDIntegration spec

### DIFF
--- a/api/v1alpha1/pagerdutyintegration_types.go
+++ b/api/v1alpha1/pagerdutyintegration_types.go
@@ -56,6 +56,15 @@ type PagerDutyIntegrationSpec struct {
 
 	// Configures alert grouping for PD services
 	AlertGroupingParameters *AlertGroupingParametersSpec `json:"alertGroupingParameters,omitempty"`
+
+	// ID of the CAD service in PagerDuty.
+	// If set, the operator will fetch the integration key for this service
+	// and distribute it to clusters as CAD_PAGERDUTY_KEY.
+	CADServiceID string `json:"cadServiceID,omitempty"`
+
+	// ID of the CAD integration within the CAD service.
+	// Required if CADServiceID is set.
+	CADIntegrationID string `json:"cadIntegrationID,omitempty"`
 }
 
 // ServiceOrchestration defines if the service orchestration is enabled

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ const (
 	PagerDutyAPISecretName string = "pagerduty-api-key" // #nosec G101 -- This is a false positive
 	PagerDutyAPISecretKey  string = "PAGERDUTY_API_KEY" // #nosec G101 -- This is a false positive
 	PagerDutySecretKey     string = "PAGERDUTY_KEY"     // #nosec G101 -- This is a false positive
+	CADPagerDutySecretKey  string = "CAD_PAGERDUTY_KEY" // #nosec G101 -- This is a false positive
 	// PagerDutyFinalizerPrefix prefix used for finalizers on resources other than PDI
 	PagerDutyFinalizerPrefix string = "pd.managed.openshift.io/"
 	// PagerDutyIntegrationFinalizer name of finalizer used for PDI

--- a/controllers/pagerdutyintegration/pagerdutyintegration_controller_test.go
+++ b/controllers/pagerdutyintegration/pagerdutyintegration_controller_test.go
@@ -171,7 +171,7 @@ func testCDSecret() *corev1.Secret {
 // testCDSyncSet returns a SyncSet for an existing testClusterDeployment to use in testing.
 func testCDSyncSet() *hivev1.SyncSet {
 	secretName := config.Name(testServicePrefix, testClusterName, config.SecretSuffix)
-	secret := kube.GeneratePdSecret(testNamespace, secretName, testIntegrationID)
+	secret := kube.GeneratePdSecret(testNamespace, secretName, testIntegrationID, "")
 	pdi := testPagerDutyIntegration()
 	ss := kube.GenerateSyncSet(testNamespace, testClusterName, secret, pdi)
 	return ss

--- a/pkg/kube/syncset.go
+++ b/pkg/kube/syncset.go
@@ -56,7 +56,16 @@ func GenerateSyncSet(namespace string, clusterDeploymentName string, secret *cor
 }
 
 // GeneratePdSecret returns a secret that can be created with the oc client
-func GeneratePdSecret(namespace string, name string, pdIntegrationKey string) *corev1.Secret {
+func GeneratePdSecret(namespace string, name string, pdIntegrationKey string, cadIntegrationKey string) *corev1.Secret {
+	secretData := map[string][]byte{
+		config.PagerDutySecretKey: []byte(pdIntegrationKey),
+	}
+
+	// Add CAD integration key if provided
+	if cadIntegrationKey != "" {
+		secretData[config.CADPagerDutySecretKey] = []byte(cadIntegrationKey)
+	}
+
 	secret := &corev1.Secret{
 		Type: "Opaque",
 		TypeMeta: metav1.TypeMeta{
@@ -67,9 +76,7 @@ func GeneratePdSecret(namespace string, name string, pdIntegrationKey string) *c
 			Name:      name,
 			Namespace: namespace,
 		},
-		Data: map[string][]byte{
-			config.PagerDutySecretKey: []byte(pdIntegrationKey),
-		},
+		Data: secretData,
 	}
 
 	return secret


### PR DESCRIPTION
Keeping in `do-not-merge` until the it's sure that the implementation is right. 

For reviewer context, see:
* https://github.com/openshift/configure-alertmanager-operator/pull/456
* https://issues.redhat.com/browse/SREP-1883