### PR TITLE
Add rollout validation scripts

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819
 
 ENV USER_UID=1001 \
     USER_NAME=pagerduty-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,226 @@
+# PagerDuty Operator Validation Scripts
+
+Validation scripts for testing pagerduty-operator rollouts across integration, staging, and production hives.
+
+All scripts are **READ-ONLY** — they do not modify any cluster or PagerDuty resources. Secret content is never read or decoded.
+
+## Quick Start
+
+### Prerequisites
+
+- Logged into a hive cluster: `ocm backplane login <hive>`
+- A Jira ticket URL for elevation justification
+- `jq`, `ocm`, and `oc` CLI tools available
+
+### Running Validations with Make
+
+```bash
+# Set your Jira ticket
+REASON="https://redhat.atlassian.net/browse/SREP-XXXX"
+
+# Run all validations (deployment + functional + metrics)
+make -f scripts/validate.mk validate REASON=$REASON
+
+# Or run individually
+make -f scripts/validate.mk validate-deployment REASON=$REASON
+make -f scripts/validate.mk validate-functional REASON=$REASON
+make -f scripts/validate.mk validate-metrics REASON=$REASON
+```
+
+### Baseline Workflow
+
+```bash
+# Before promotion: capture baseline on each target hive
+ocm backplane login hive-stage-01
+make -f scripts/validate.mk baseline REASON=$REASON
+
+# After promotion: compare against baseline
+make -f scripts/validate.mk compare REASON=$REASON BASELINE=/tmp/baselines/baseline-hive-stage-01-20260318.json
+```
+
+### Make Targets
+
+| Target | Description |
+|--------|-------------|
+| `help` | Show available targets and usage |
+| `baseline` | Capture metrics baseline (saves to `/tmp/baselines/`) |
+| `compare` | Compare current metrics against a baseline file (`BASELINE=<file>` required) |
+| `validate` | Run all three validations in sequence |
+| `validate-deployment` | Deployment health only |
+| `validate-functional` | Functional behavior only |
+| `validate-metrics` | Prometheus metrics only |
+
+All targets require `REASON=<jira-ticket-url>`. Optional variables: `NAMESPACE` (default: `pagerduty-operator`), `BASELINE_DIR` (default: `/tmp/baselines`), `VERBOSE` (default: `-v`).
+
+## Validating a Rollout
+
+### 1. Capture Baselines (Before Promotion)
+
+On each target hive, capture a metrics snapshot:
+
+```bash
+ocm backplane login <hive>
+make -f scripts/validate.mk baseline REASON=$REASON
+```
+
+Repeat for all target hives. Baselines are saved to `/tmp/baselines/baseline-<hive>-<date>.json`.
+
+### 2. After Promotion, Validate Each Hive
+
+```bash
+ocm backplane login <hive>
+make -f scripts/validate.mk validate REASON=$REASON
+```
+
+This runs deployment, functional, and metrics checks in sequence.
+
+### 3. Compare Against Baselines
+
+```bash
+make -f scripts/validate.mk compare REASON=$REASON BASELINE=/tmp/baselines/baseline-<hive>-<date>.json
+```
+
+### 4. Progression Order
+
+1. **Integration** (1 hive) — validate, capture baseline
+2. **Staging** (3 hives) — may auto-promote; validate all 3
+3. **Production** (8 hives) — validate a representative sample
+
+If `validate-functional` reports "no new clusters since rollout", wait for cluster provisioning or re-run later.
+
+## Script Details
+
+### validate-deployment.sh
+
+**Purpose**: Is the operator pod running and healthy?
+
+**Checks**:
+- Cluster connection verified
+- Operator namespace exists
+- Pod is `Running` with 0 restarts
+- Pod image/version reported
+- Error-level logs scanned (benign "namespace terminating" errors filtered separately)
+- Deployment has desired replicas available and ready
+
+**Elevation**: All `oc` commands go through `ocm backplane elevate` using the provided ticket.
+
+**Usage**:
+```bash
+./validate-deployment.sh -t <ticket-url> [-v] [-j] [-n namespace]
+```
+
+### validate-functional.sh
+
+**Purpose**: Is the operator actively creating PagerDuty services for new clusters?
+
+**Checks**:
+1. **PagerDutyIntegration CRs** — verifies they exist and have active finalizers; collects service prefixes used for resource naming
+2. **Operator rollout time** — determines when the current pod started (i.e., when the new version began running)
+3. **New ClusterDeployments** — finds clusters installed *after* the operator rollout, proving the current version handled them
+4. **Spot-check PD resources** — selects up to 3 representative new clusters (first, middle, last by install time) and validates each with a single bulk API call (`oc get configmap,secret,syncset -n <ns>`):
+   - **ConfigMap** (`{prefix}-{cdName}-pd-config`): has `SERVICE_ID`, `INTEGRATION_ID`, `ESCALATION_POLICY_ID`
+   - **Secret** (`{prefix}-{cdName}-pd-secret`): exists (content is NOT read or decoded)
+   - **SyncSet** (`{prefix}-{cdName}-pd-secret`): references correct ClusterDeployment, `resourceApplyMode: Sync`, valid `secretMappings` with source and target refs
+   - **PD finalizer**: present on the ClusterDeployment
+5. **PD finalizer coverage** — checks all new eligible CDs have PD finalizers (filters out fake, nightly, and noalerts clusters which are excluded by design)
+6. **Log activity** — heartbeat (PD API ping every 5 min), successful reconciliations, error classification
+7. **Creation evidence** — searches logs for `creating pd secret` entries for new cluster namespaces
+
+**No new clusters?** If no clusters were provisioned since the operator rollout, the script reports clearly and suggests waiting or requesting a test cluster.
+
+**Resource scoping**: All resource lookups are scoped to namespaces where ClusterDeployments actually exist — no `--all-namespaces` sweeps for ConfigMaps, Secrets, or SyncSets.
+
+**Usage**:
+```bash
+./validate-functional.sh -t <ticket-url> [-v] [-j] [-n namespace]
+```
+
+### check-metrics.sh
+
+**Purpose**: Are the operator's Prometheus metrics healthy?
+
+**Checks**:
+- `pagerdutyintegration_secret_loaded == 1` (PD API key loaded)
+- `pagerduty_create_failure == 0` (no service creation failures)
+- `pagerduty_delete_failure == 0` (no service deletion failures)
+- `pagerduty_heartbeat_count > 0` (PD API reachable)
+- `pagerduty_operator_reconcile_duration_seconds` p95/p99 within bounds
+
+**How it works**: Queries the app-sre Prometheus instance in `openshift-customer-monitoring` via `ocm backplane elevate ... exec` into the Prometheus pod using `wget`.
+
+**Usage**:
+```bash
+./check-metrics.sh -t <ticket-url> [-v] [-j] [-n namespace]
+```
+
+### compare-metrics.sh
+
+**Purpose**: Has anything regressed compared to a pre-promotion baseline?
+
+**Modes**:
+- `--baseline`: Captures a metrics snapshot as JSON (pipe to a file)
+- `--compare <file>`: Compares current metrics against a saved baseline
+
+**Metrics compared**:
+- Secret loaded status
+- Create/delete failure counts
+- Heartbeat count
+- Reconciliation latency (p50, p95, p99) with % change
+- API request latency with % change
+- Pod CPU and memory usage with % change
+
+**Thresholds**: Warns at >50% latency increase, fails at >100%. Warns at >50% memory increase.
+
+**Usage**:
+```bash
+# Capture
+./compare-metrics.sh --baseline -t <ticket-url> > baseline.json
+
+# Compare
+./compare-metrics.sh --compare baseline.json -t <ticket-url> [-v]
+```
+
+### validation-suite.sh
+
+**Purpose**: Orchestrates all validation checks in sequence.
+
+**Note**: The `make validate` target provides equivalent functionality and is the recommended way to run the full suite.
+
+## Output
+
+### Standard Output
+
+Color-coded, human-readable:
+- ✅ Green — check passed
+- ❌ Red — check failed
+- ⚠️  Yellow — warning (non-critical issue)
+- 🔵 Blue — action needed (e.g., no new clusters to validate)
+
+### JSON Output
+
+Use `-j` flag for machine-readable output. All scripts support this.
+
+### Exit Codes
+
+- `0` — all checks passed (or passed with warnings)
+- `1` — one or more checks failed
+
+## Troubleshooting
+
+### "REASON is required"
+Set `REASON` to a Jira ticket URL: `REASON=https://redhat.atlassian.net/browse/SREP-XXXX`
+
+### "Not logged into a cluster"
+Run `ocm backplane login <hive>` first.
+
+### "Backplane elevation failed"
+Verify the Jira ticket URL is correct and grants appropriate access.
+
+### "No PD API heartbeat found"
+The operator may have just started. Wait 5 minutes for the first heartbeat cycle.
+
+### "No new clusters to validate"
+The functional check only validates clusters installed after the operator rollout. If no clusters have been provisioned, wait for provisioning activity or re-run later.
+
+### Resource count mismatches
+ConfigMap/Secret/SyncSet counts should be equal. Mismatches may indicate in-progress reconciliation — re-run after a few minutes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,10 +97,13 @@ If `validate-functional` reports "no new clusters since rollout", wait for clust
 **Checks**:
 - Cluster connection verified
 - Operator namespace exists
-- Pod is `Running` with 0 restarts
-- Pod image/version reported
+- ClusterPackage status — conditions (Unpacked/Available/Progressing), PKO and operator image tags, SAAS update timestamp, generation vs observed generation
+- Pod is `Running` with 0 restarts, image tag reported
+- Pod image matches ClusterPackage spec (detects stale pods during rollout)
+- ReplicaSet rollout state — active vs scaled-down ReplicaSets (detects in-progress or stuck rollouts)
 - Error-level logs scanned (benign "namespace terminating" errors filtered separately)
 - Deployment has desired replicas available and ready
+- Image pull failure detection — catches `ErrImagePull`/`ImagePullBackOff` when SAAS deploy races the Konflux build
 
 **Elevation**: All `oc` commands go through `ocm backplane elevate` using the provided ticket.
 
@@ -221,6 +224,15 @@ The operator may have just started. Wait 5 minutes for the first heartbeat cycle
 
 ### "No new clusters to validate"
 The functional check only validates clusters installed after the operator rollout. If no clusters have been provisioned, wait for provisioning activity or re-run later.
+
+### "Image pull failure detected — SAAS deploy may have raced the Konflux build"
+The SAAS deploy pipeline updated the ClusterPackage before the Konflux build finished pushing the operator image to Quay. The old pod remains running (no outage). Wait for the Konflux build to complete and the image to appear, then the new pod will start automatically.
+
+### "ClusterPackage update in progress"
+A SAAS deploy has updated the ClusterPackage but the new pod hasn't started yet. This is normal during rollout — re-run after a few minutes.
+
+### "Pod image does not match ClusterPackage spec"
+The running pod is still on the old image while the ClusterPackage specifies a new one. The rollout is in progress. Check ReplicaSet state for details.
 
 ### Resource count mismatches
 ConfigMap/Secret/SyncSet counts should be equal. Mismatches may indicate in-progress reconciliation — re-run after a few minutes.

--- a/scripts/check-metrics.sh
+++ b/scripts/check-metrics.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+# check-metrics.sh - Validate pagerduty-operator Prometheus metrics
+#
+# Usage: ./check-metrics.sh [OPTIONS]
+#
+# Options:
+#   -n, --namespace NAMESPACE    Operator namespace (default: pagerduty-operator)
+#   -t, --ticket TICKET          SREP ticket number for elevation (required)
+#   -j, --json                   Output results in JSON format
+#   -v, --verbose                Verbose output
+#   -h, --help                   Show this help message
+#
+# Prerequisites:
+#   - Must be logged into the hive cluster with oc
+#   - Must have ocm backplane access
+#   - Must provide SREP ticket for elevation
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Default values
+NAMESPACE="pagerduty-operator"
+TICKET=""
+JSON_OUTPUT=false
+VERBOSE=false
+
+# Prometheus details
+PROMETHEUS_NAMESPACE="openshift-customer-monitoring"
+PROMETHEUS_POD=""
+
+# Results tracking
+CHECKS_PASSED=0
+CHECKS_FAILED=0
+CHECKS_WARNING=0
+RESULTS=()
+
+# Helper functions
+log_info() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${NC}$1${NC}"
+    fi
+}
+
+log_success() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${GREEN}✅ $1${NC}"
+    fi
+    CHECKS_PASSED=$((CHECKS_PASSED + 1))
+    RESULTS+=("{\"check\":\"$2\",\"status\":\"pass\",\"message\":\"$1\",\"value\":\"$3\"}")
+}
+
+log_fail() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${RED}❌ $1${NC}"
+    fi
+    CHECKS_FAILED=$((CHECKS_FAILED + 1))
+    RESULTS+=("{\"check\":\"$2\",\"status\":\"fail\",\"message\":\"$1\",\"value\":\"$3\"}")
+}
+
+log_warning() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${YELLOW}⚠️  $1${NC}"
+    fi
+    CHECKS_WARNING=$((CHECKS_WARNING + 1))
+    RESULTS+=("{\"check\":\"$2\",\"status\":\"warning\",\"message\":\"$1\",\"value\":\"$3\"}")
+}
+
+verbose() {
+    if [[ "$VERBOSE" == "true" && "$JSON_OUTPUT" == "false" ]]; then
+        echo "  → $1"
+    fi
+}
+
+show_help() {
+    grep '^#' "$0" | grep -v '#!/bin/bash' | sed 's/^# //' | sed 's/^#//'
+    exit 0
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -n|--namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        -t|--ticket)
+            TICKET="$2"
+            shift 2
+            ;;
+        -j|--json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "$TICKET" ]]; then
+    echo "Error: SREP ticket number is required (-t|--ticket)"
+    echo ""
+    show_help
+fi
+
+# Query Prometheus via backplane elevation
+query_prometheus() {
+    local query="$1"
+    local result=""
+
+    verbose "Querying Prometheus: $query"
+
+    # Use ocm backplane elevate to execute query inside prometheus pod
+    result=$(ocm backplane elevate "$TICKET" -- exec -n "$PROMETHEUS_NAMESPACE" "$PROMETHEUS_POD" -c prometheus -- \
+        sh -c "wget -q -O- 'http://localhost:9090/api/v1/query?query=$(echo "$query" | jq -sRr @uri)'" 2>/dev/null || echo '{"status":"error"}')
+
+    echo "$result"
+}
+
+# Extract metric value from Prometheus response
+extract_value() {
+    local response="$1"
+    local value=""
+
+    # Check if query was successful
+    if [[ $(echo "$response" | jq -r '.status' 2>/dev/null) != "success" ]]; then
+        echo "ERROR"
+        return 1
+    fi
+
+    # Extract first result value
+    value=$(echo "$response" | jq -r '.data.result[0].value[1] // "NODATA"' 2>/dev/null)
+    echo "$value"
+}
+
+# Extract histogram quantile
+extract_histogram_quantile() {
+    local metric_name="$1"
+    local quantile="$2"
+    local query="histogram_quantile($quantile, rate(${metric_name}_bucket[5m]))"
+
+    local response=$(query_prometheus "$query")
+    extract_value "$response"
+}
+
+# Main validation logic
+main() {
+    log_info "Starting pagerduty-operator metrics validation"
+    log_info "Namespace: $NAMESPACE"
+    log_info "SREP Ticket: $TICKET"
+    log_info ""
+
+    # Check 1: Verify cluster connection
+    log_info "[1/8] Verifying cluster connection..."
+    if ! oc whoami &>/dev/null; then
+        log_fail "Not logged into a cluster" "cluster_connection" "N/A"
+        exit 1
+    fi
+    log_success "Connected to cluster" "cluster_connection" "$(oc whoami --show-server)"
+
+    # Check 2: Find Prometheus pod
+    log_info "[2/8] Finding Prometheus pod..."
+    PROMETHEUS_POD=$(oc get pods -n "$PROMETHEUS_NAMESPACE" -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+    # If not found, might be named prometheus-app-sre
+    if [[ -z "$PROMETHEUS_POD" ]]; then
+        PROMETHEUS_POD=$(oc get pods -n "$PROMETHEUS_NAMESPACE" -l prometheus=app-sre -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    fi
+
+    if [[ -z "$PROMETHEUS_POD" ]]; then
+        log_fail "Could not find Prometheus pod in $PROMETHEUS_NAMESPACE" "prometheus_pod" "N/A"
+        exit 1
+    fi
+    verbose "Found Prometheus pod: $PROMETHEUS_POD"
+    log_success "Found Prometheus pod" "prometheus_pod" "$PROMETHEUS_POD"
+
+    # Check 3: Test backplane elevation
+    log_info "[3/8] Testing backplane elevation..."
+    TEST_RESULT=$(ocm backplane elevate "$TICKET" -- exec -n "$PROMETHEUS_NAMESPACE" "$PROMETHEUS_POD" -c prometheus -- echo "success" 2>/dev/null || echo "failed")
+
+    if [[ "$TEST_RESULT" != "success" ]]; then
+        log_fail "Backplane elevation failed - check ticket number and permissions" "backplane_elevation" "failed"
+        exit 1
+    fi
+    log_success "Backplane elevation successful" "backplane_elevation" "success"
+
+    # Check 4: pagerdutyintegration_secret_loaded metric
+    log_info "[4/8] Checking pagerdutyintegration_secret_loaded metric..."
+    SECRET_LOADED_RESPONSE=$(query_prometheus "pagerdutyintegration_secret_loaded")
+    SECRET_LOADED=$(extract_value "$SECRET_LOADED_RESPONSE")
+
+    if [[ "$SECRET_LOADED" == "ERROR" ]] || [[ "$SECRET_LOADED" == "NODATA" ]]; then
+        log_fail "pagerdutyintegration_secret_loaded metric not available" "secret_loaded" "$SECRET_LOADED"
+    elif [[ "$SECRET_LOADED" == "1" ]]; then
+        log_success "API secret loaded successfully" "secret_loaded" "1"
+    else
+        log_fail "API secret not loaded (value: $SECRET_LOADED)" "secret_loaded" "$SECRET_LOADED"
+    fi
+
+    # Check 5: pagerduty_create_failure metric
+    log_info "[5/8] Checking pagerduty_create_failure metric..."
+    CREATE_FAILURE_RESPONSE=$(query_prometheus "pagerduty_create_failure")
+    CREATE_FAILURE=$(extract_value "$CREATE_FAILURE_RESPONSE")
+
+    if [[ "$CREATE_FAILURE" == "ERROR" ]] || [[ "$CREATE_FAILURE" == "NODATA" ]]; then
+        log_warning "pagerduty_create_failure metric not available" "create_failure" "$CREATE_FAILURE"
+    elif [[ "$CREATE_FAILURE" == "0" ]]; then
+        log_success "No PagerDuty creation failures" "create_failure" "0"
+    else
+        log_fail "PagerDuty creation failures detected (count: $CREATE_FAILURE)" "create_failure" "$CREATE_FAILURE"
+    fi
+
+    # Check 6: pagerduty_delete_failure metric
+    log_info "[6/8] Checking pagerduty_delete_failure metric..."
+    DELETE_FAILURE_RESPONSE=$(query_prometheus "pagerduty_delete_failure")
+    DELETE_FAILURE=$(extract_value "$DELETE_FAILURE_RESPONSE")
+
+    if [[ "$DELETE_FAILURE" == "ERROR" ]] || [[ "$DELETE_FAILURE" == "NODATA" ]]; then
+        log_warning "pagerduty_delete_failure metric not available" "delete_failure" "$DELETE_FAILURE"
+    elif [[ "$DELETE_FAILURE" == "0" ]]; then
+        log_success "No PagerDuty deletion failures" "delete_failure" "0"
+    else
+        log_fail "PagerDuty deletion failures detected (count: $DELETE_FAILURE)" "delete_failure" "$DELETE_FAILURE"
+    fi
+
+    # Check 7: pagerduty_heartbeat_count metric
+    log_info "[7/8] Checking pagerduty_heartbeat_count metric..."
+    HEARTBEAT_RESPONSE=$(query_prometheus "pagerduty_heartbeat_count")
+    HEARTBEAT=$(extract_value "$HEARTBEAT_RESPONSE")
+
+    if [[ "$HEARTBEAT" == "ERROR" ]] || [[ "$HEARTBEAT" == "NODATA" ]]; then
+        log_fail "pagerduty_heartbeat_count metric not available" "heartbeat" "$HEARTBEAT"
+    elif awk -v hb="$HEARTBEAT" 'BEGIN { exit !(hb > 0) }'; then
+        log_success "PagerDuty API heartbeat active (count: $HEARTBEAT)" "heartbeat" "$HEARTBEAT"
+    else
+        log_fail "PagerDuty API heartbeat not active (count: $HEARTBEAT)" "heartbeat" "$HEARTBEAT"
+    fi
+
+    # Check 8: Reconciliation latency
+    log_info "[8/8] Checking reconciliation latency..."
+    P50=$(extract_histogram_quantile "pagerduty_operator_reconcile_duration_seconds" "0.5")
+    P95=$(extract_histogram_quantile "pagerduty_operator_reconcile_duration_seconds" "0.95")
+    P99=$(extract_histogram_quantile "pagerduty_operator_reconcile_duration_seconds" "0.99")
+
+    verbose "p50: ${P50}s | p95: ${P95}s | p99: ${P99}s"
+
+    if [[ "$P95" == "ERROR" ]] || [[ "$P95" == "NODATA" ]]; then
+        log_warning "Reconciliation latency metrics not available" "reconciliation_latency" "N/A"
+    else
+        # Check if p95 < 2s and p99 < 5s
+        if awk -v p95="$P95" -v p99="$P99" 'BEGIN { exit !(p95 < 2 && p99 < 5) }'; then
+            log_success "Reconciliation latency within expected range (p95: ${P95}s, p99: ${P99}s)" "reconciliation_latency" "p95:${P95},p99:${P99}"
+        elif awk -v p95="$P95" -v p99="$P99" 'BEGIN { exit !(p95 >= 2 || p99 >= 5) }'; then
+            log_warning "Reconciliation latency elevated (p95: ${P95}s, p99: ${P99}s)" "reconciliation_latency" "p95:${P95},p99:${P99}"
+        else
+            log_success "Reconciliation latency (p50: ${P50}s, p95: ${P95}s, p99: ${P99}s)" "reconciliation_latency" "p50:${P50},p95:${P95},p99:${P99}"
+        fi
+    fi
+
+    # Summary
+    log_info ""
+    log_info "========================================="
+    log_info "Metrics Validation Summary"
+    log_info "========================================="
+
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        # Output JSON results
+        echo "{"
+        echo "  \"namespace\": \"$NAMESPACE\","
+        echo "  \"ticket\": \"$TICKET\","
+        echo "  \"prometheus_pod\": \"$PROMETHEUS_POD\","
+        echo "  \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
+        echo "  \"summary\": {"
+        echo "    \"passed\": $CHECKS_PASSED,"
+        echo "    \"failed\": $CHECKS_FAILED,"
+        echo "    \"warnings\": $CHECKS_WARNING"
+        echo "  },"
+        echo "  \"checks\": ["
+        echo "    $(IFS=,; echo "${RESULTS[*]}")"
+        echo "  ]"
+        echo "}"
+    else
+        log_info "Passed:   $CHECKS_PASSED"
+        log_info "Failed:   $CHECKS_FAILED"
+        log_info "Warnings: $CHECKS_WARNING"
+        log_info ""
+
+        if [[ $CHECKS_FAILED -gt 0 ]]; then
+            log_fail "Metrics validation FAILED - $CHECKS_FAILED critical issues found" "overall" "N/A"
+            exit 1
+        elif [[ $CHECKS_WARNING -gt 0 ]]; then
+            log_warning "Metrics validation PASSED with $CHECKS_WARNING warning(s)" "overall" "N/A"
+            exit 0
+        else
+            log_success "Metrics validation PASSED - All checks successful" "overall" "N/A"
+            exit 0
+        fi
+    fi
+}
+
+main

--- a/scripts/check-metrics.sh
+++ b/scripts/check-metrics.sh
@@ -174,11 +174,11 @@ main() {
 
     # Check 2: Find Prometheus pod
     log_info "[2/8] Finding Prometheus pod..."
-    PROMETHEUS_POD=$(oc get pods -n "$PROMETHEUS_NAMESPACE" -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    PROMETHEUS_POD=$(ocm backplane elevate "$TICKET" -- get pods -n "$PROMETHEUS_NAMESPACE" -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
 
     # If not found, might be named prometheus-app-sre
     if [[ -z "$PROMETHEUS_POD" ]]; then
-        PROMETHEUS_POD=$(oc get pods -n "$PROMETHEUS_NAMESPACE" -l prometheus=app-sre -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+        PROMETHEUS_POD=$(ocm backplane elevate "$TICKET" -- get pods -n "$PROMETHEUS_NAMESPACE" -l prometheus=app-sre -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
     fi
 
     if [[ -z "$PROMETHEUS_POD" ]]; then

--- a/scripts/check-metrics.sh
+++ b/scripts/check-metrics.sh
@@ -293,6 +293,9 @@ main() {
         echo "    $(IFS=,; echo "${RESULTS[*]}")"
         echo "  ]"
         echo "}"
+        if [[ $CHECKS_FAILED -gt 0 ]]; then
+            exit 1
+        fi
     else
         log_info "Passed:   $CHECKS_PASSED"
         log_info "Failed:   $CHECKS_FAILED"

--- a/scripts/compare-metrics.sh
+++ b/scripts/compare-metrics.sh
@@ -1,0 +1,370 @@
+#!/bin/bash
+# compare-metrics.sh - Compare pagerduty-operator metrics before/after deployment
+#
+# Usage:
+#   ./compare-metrics.sh --baseline -t TICKET > baseline.json
+#   ./compare-metrics.sh --compare baseline.json -t TICKET
+#
+# Options:
+#   -n, --namespace NAMESPACE    Operator namespace (default: pagerduty-operator)
+#   -t, --ticket TICKET          SREP ticket number for elevation (required)
+#   -b, --baseline               Capture baseline metrics snapshot
+#   -c, --compare FILE           Compare current metrics against baseline file
+#   -v, --verbose                Verbose output
+#   -h, --help                   Show this help message
+#
+# Prerequisites:
+#   - Must be logged into the hive cluster with oc
+#   - Must have ocm backplane access
+#   - Must provide SREP ticket for elevation
+#
+# Note: This script is READ-ONLY and does not modify any resources
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Default values
+NAMESPACE="pagerduty-operator"
+TICKET=""
+BASELINE_MODE=false
+COMPARE_MODE=false
+COMPARE_FILE=""
+VERBOSE=false
+
+# Prometheus details
+PROMETHEUS_NAMESPACE="openshift-customer-monitoring"
+PROMETHEUS_POD=""
+
+# Helper functions
+log_info() {
+    echo -e "${NC}$1${NC}" >&2
+}
+
+log_success() {
+    echo -e "${GREEN}✅ $1${NC}" >&2
+}
+
+log_fail() {
+    echo -e "${RED}❌ $1${NC}" >&2
+}
+
+log_warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}" >&2
+}
+
+verbose() {
+    if [[ "$VERBOSE" == "true" ]]; then
+        echo "  → $1" >&2
+    fi
+}
+
+show_help() {
+    grep '^#' "$0" | grep -v '#!/bin/bash' | sed 's/^# //' | sed 's/^#//'
+    exit 0
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -n|--namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        -t|--ticket)
+            TICKET="$2"
+            shift 2
+            ;;
+        -b|--baseline)
+            BASELINE_MODE=true
+            shift
+            ;;
+        -c|--compare)
+            COMPARE_MODE=true
+            COMPARE_FILE="$2"
+            shift 2
+            ;;
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            show_help
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "$TICKET" ]]; then
+    echo "Error: SREP ticket number is required (-t|--ticket)" >&2
+    echo "" >&2
+    show_help
+fi
+
+if [[ "$BASELINE_MODE" == "false" && "$COMPARE_MODE" == "false" ]]; then
+    echo "Error: Must specify either --baseline or --compare FILE" >&2
+    echo "" >&2
+    show_help
+fi
+
+if [[ "$BASELINE_MODE" == "true" && "$COMPARE_MODE" == "true" ]]; then
+    echo "Error: Cannot specify both --baseline and --compare" >&2
+    echo "" >&2
+    show_help
+fi
+
+if [[ "$COMPARE_MODE" == "true" && ! -f "$COMPARE_FILE" ]]; then
+    echo "Error: Baseline file not found: $COMPARE_FILE" >&2
+    exit 1
+fi
+
+# Query Prometheus via backplane elevation
+query_prometheus() {
+    local query="$1"
+    local result=""
+
+    verbose "Querying Prometheus: $query"
+
+    # Use ocm backplane elevate to execute query inside prometheus pod
+    result=$(ocm backplane elevate "$TICKET" -- exec -n "$PROMETHEUS_NAMESPACE" "$PROMETHEUS_POD" -c prometheus -- \
+        sh -c "wget -q -O- 'http://localhost:9090/api/v1/query?query=$(echo "$query" | jq -sRr @uri)'" 2>/dev/null || echo '{"status":"error"}')
+
+    echo "$result"
+}
+
+# Extract metric value from Prometheus response
+extract_value() {
+    local response="$1"
+    local default="${2:-0}"
+
+    # Check if query was successful
+    if [[ $(echo "$response" | jq -r '.status' 2>/dev/null) != "success" ]]; then
+        echo "$default"
+        return 1
+    fi
+
+    # Extract first result value
+    local value=$(echo "$response" | jq -r ".data.result[0].value[1] // \"$default\"" 2>/dev/null)
+    echo "$value"
+}
+
+# Extract histogram quantile
+extract_histogram_quantile() {
+    local metric_name="$1"
+    local quantile="$2"
+    local query="histogram_quantile($quantile, rate(${metric_name}_bucket[5m]))"
+
+    local response=$(query_prometheus "$query")
+    extract_value "$response" "0"
+}
+
+# Capture current metrics snapshot
+capture_metrics() {
+    log_info "Capturing metrics snapshot..." >&2
+
+    # Find Prometheus pod
+    PROMETHEUS_POD=$(oc get pods -n "$PROMETHEUS_NAMESPACE" -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+    # If not found, might be named prometheus-app-sre
+    if [[ -z "$PROMETHEUS_POD" ]]; then
+        PROMETHEUS_POD=$(oc get pods -n "$PROMETHEUS_NAMESPACE" -l prometheus=app-sre -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    fi
+
+    if [[ -z "$PROMETHEUS_POD" ]]; then
+        log_fail "Could not find Prometheus pod in $PROMETHEUS_NAMESPACE" >&2
+        exit 1
+    fi
+    verbose "Found Prometheus pod: $PROMETHEUS_POD"
+
+    # Test backplane elevation
+    TEST_RESULT=$(ocm backplane elevate "$TICKET" -- exec -n "$PROMETHEUS_NAMESPACE" "$PROMETHEUS_POD" -c prometheus -- echo "success" 2>/dev/null || echo "failed")
+
+    if [[ "$TEST_RESULT" != "success" ]]; then
+        log_fail "Backplane elevation failed - check ticket number and permissions" >&2
+        exit 1
+    fi
+
+    # Capture metrics
+    verbose "Querying metrics..."
+
+    SECRET_LOADED=$(extract_value "$(query_prometheus 'pagerdutyintegration_secret_loaded')")
+    CREATE_FAILURE=$(extract_value "$(query_prometheus 'pagerduty_create_failure')")
+    DELETE_FAILURE=$(extract_value "$(query_prometheus 'pagerduty_delete_failure')")
+    HEARTBEAT=$(extract_value "$(query_prometheus 'pagerduty_heartbeat_count')")
+
+    RECONCILE_P50=$(extract_histogram_quantile "pagerduty_operator_reconcile_duration_seconds" "0.5")
+    RECONCILE_P95=$(extract_histogram_quantile "pagerduty_operator_reconcile_duration_seconds" "0.95")
+    RECONCILE_P99=$(extract_histogram_quantile "pagerduty_operator_reconcile_duration_seconds" "0.99")
+
+    API_P50=$(extract_histogram_quantile "pagerduty_operator_api_request_duration_seconds" "0.5")
+    API_P95=$(extract_histogram_quantile "pagerduty_operator_api_request_duration_seconds" "0.95")
+    API_P99=$(extract_histogram_quantile "pagerduty_operator_api_request_duration_seconds" "0.99")
+
+    # Get pod resource usage
+    POD_NAME=$(oc get pods -n "$NAMESPACE" -l name=pagerduty-operator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    POD_MEMORY="0"
+    POD_CPU="0"
+
+    if [[ -n "$POD_NAME" ]]; then
+        POD_METRICS=$(oc adm top pod -n "$NAMESPACE" "$POD_NAME" --no-headers 2>/dev/null || echo "")
+        if [[ -n "$POD_METRICS" ]]; then
+            POD_CPU=$(echo "$POD_METRICS" | awk '{print $2}' | sed 's/m//')
+            POD_MEMORY=$(echo "$POD_METRICS" | awk '{print $3}' | sed 's/Mi//')
+        fi
+    fi
+
+    # Output JSON
+    cat <<EOF
+{
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "namespace": "$NAMESPACE",
+  "cluster": "$(oc whoami --show-server)",
+  "metrics": {
+    "secret_loaded": $SECRET_LOADED,
+    "create_failure": $CREATE_FAILURE,
+    "delete_failure": $DELETE_FAILURE,
+    "heartbeat_count": $HEARTBEAT,
+    "reconcile_latency": {
+      "p50": $RECONCILE_P50,
+      "p95": $RECONCILE_P95,
+      "p99": $RECONCILE_P99
+    },
+    "api_latency": {
+      "p50": $API_P50,
+      "p95": $API_P95,
+      "p99": $API_P99
+    },
+    "resources": {
+      "cpu_millicores": $POD_CPU,
+      "memory_mib": $POD_MEMORY
+    }
+  }
+}
+EOF
+}
+
+# Compare current metrics against baseline
+compare_metrics() {
+    log_info "Comparing metrics against baseline: $COMPARE_FILE" >&2
+
+    # Load baseline
+    BASELINE=$(cat "$COMPARE_FILE")
+    BASELINE_TIME=$(echo "$BASELINE" | jq -r '.timestamp')
+
+    log_info "Baseline captured: $BASELINE_TIME" >&2
+    log_info "" >&2
+
+    # Capture current metrics
+    CURRENT=$(capture_metrics)
+
+    # Extract baseline values
+    B_SECRET=$(echo "$BASELINE" | jq -r '.metrics.secret_loaded')
+    B_CREATE_FAIL=$(echo "$BASELINE" | jq -r '.metrics.create_failure')
+    B_DELETE_FAIL=$(echo "$BASELINE" | jq -r '.metrics.delete_failure')
+    B_HEARTBEAT=$(echo "$BASELINE" | jq -r '.metrics.heartbeat_count')
+    B_RECONCILE_P95=$(echo "$BASELINE" | jq -r '.metrics.reconcile_latency.p95')
+    B_RECONCILE_P99=$(echo "$BASELINE" | jq -r '.metrics.reconcile_latency.p99')
+    B_API_P95=$(echo "$BASELINE" | jq -r '.metrics.api_latency.p95')
+    B_CPU=$(echo "$BASELINE" | jq -r '.metrics.resources.cpu_millicores')
+    B_MEMORY=$(echo "$BASELINE" | jq -r '.metrics.resources.memory_mib')
+
+    # Extract current values
+    C_SECRET=$(echo "$CURRENT" | jq -r '.metrics.secret_loaded')
+    C_CREATE_FAIL=$(echo "$CURRENT" | jq -r '.metrics.create_failure')
+    C_DELETE_FAIL=$(echo "$CURRENT" | jq -r '.metrics.delete_failure')
+    C_HEARTBEAT=$(echo "$CURRENT" | jq -r '.metrics.heartbeat_count')
+    C_RECONCILE_P95=$(echo "$CURRENT" | jq -r '.metrics.reconcile_latency.p95')
+    C_RECONCILE_P99=$(echo "$CURRENT" | jq -r '.metrics.reconcile_latency.p99')
+    C_API_P95=$(echo "$CURRENT" | jq -r '.metrics.api_latency.p95')
+    C_CPU=$(echo "$CURRENT" | jq -r '.metrics.resources.cpu_millicores')
+    C_MEMORY=$(echo "$CURRENT" | jq -r '.metrics.resources.memory_mib')
+
+    # Compare and report
+    log_info "=========================================" >&2
+    log_info "Metrics Comparison" >&2
+    log_info "=========================================" >&2
+
+    # Secret loaded
+    if [[ "$C_SECRET" == "$B_SECRET" && "$C_SECRET" == "1" ]]; then
+        log_success "Secret loaded: OK (both 1)" >&2
+    elif [[ "$C_SECRET" != "1" ]]; then
+        log_fail "Secret loaded: FAILED (current: $C_SECRET, baseline: $B_SECRET)" >&2
+    fi
+
+    # Failures
+    if [[ "$C_CREATE_FAIL" == "0" && "$C_DELETE_FAIL" == "0" ]]; then
+        log_success "No create/delete failures" >&2
+    else
+        log_fail "Failures detected - Create: $C_CREATE_FAIL (baseline: $B_CREATE_FAIL), Delete: $C_DELETE_FAIL (baseline: $B_DELETE_FAIL)" >&2
+    fi
+
+    # Heartbeat
+    if awk -v hb="$C_HEARTBEAT" 'BEGIN { exit !(hb > 0) }'; then
+        log_success "Heartbeat active: $C_HEARTBEAT (baseline: $B_HEARTBEAT)" >&2
+    else
+        log_fail "Heartbeat inactive: $C_HEARTBEAT (baseline: $B_HEARTBEAT)" >&2
+    fi
+
+    # Reconcile latency
+    RECONCILE_P95_CHANGE=$(awk -v c="$C_RECONCILE_P95" -v b="$B_RECONCILE_P95" 'BEGIN { printf "%.2f", (c - b) / b * 100 }')
+    RECONCILE_P99_CHANGE=$(awk -v c="$C_RECONCILE_P99" -v b="$B_RECONCILE_P99" 'BEGIN { printf "%.2f", (c - b) / b * 100 }')
+
+    log_info "" >&2
+    log_info "Reconciliation Latency:" >&2
+    log_info "  p95: ${C_RECONCILE_P95}s (baseline: ${B_RECONCILE_P95}s, change: ${RECONCILE_P95_CHANGE}%)" >&2
+    log_info "  p99: ${C_RECONCILE_P99}s (baseline: ${B_RECONCILE_P99}s, change: ${RECONCILE_P99_CHANGE}%)" >&2
+
+    if awk -v change="$RECONCILE_P95_CHANGE" 'BEGIN { exit !(change > 100) }'; then
+        log_fail "Reconcile p95 latency increased >100% (${RECONCILE_P95_CHANGE}%)" >&2
+    elif awk -v change="$RECONCILE_P95_CHANGE" 'BEGIN { exit !(change > 50) }'; then
+        log_warning "Reconcile p95 latency increased >50% (${RECONCILE_P95_CHANGE}%)" >&2
+    else
+        log_success "Reconcile latency within acceptable range" >&2
+    fi
+
+    # API latency
+    API_P95_CHANGE=$(awk -v c="$C_API_P95" -v b="$B_API_P95" 'BEGIN { if (b > 0) printf "%.2f", (c - b) / b * 100; else print "0" }')
+
+    log_info "" >&2
+    log_info "API Request Latency:" >&2
+    log_info "  p95: ${C_API_P95}s (baseline: ${B_API_P95}s, change: ${API_P95_CHANGE}%)" >&2
+
+    # Memory
+    MEMORY_CHANGE=$(awk -v c="$C_MEMORY" -v b="$B_MEMORY" 'BEGIN { if (b > 0) printf "%.2f", (c - b) / b * 100; else print "0" }')
+
+    log_info "" >&2
+    log_info "Resource Usage:" >&2
+    log_info "  CPU: ${C_CPU}m (baseline: ${B_CPU}m)" >&2
+    log_info "  Memory: ${C_MEMORY}Mi (baseline: ${B_MEMORY}Mi, change: ${MEMORY_CHANGE}%)" >&2
+
+    if awk -v change="$MEMORY_CHANGE" 'BEGIN { exit !(change > 50) }'; then
+        log_warning "Memory usage increased >50% (${MEMORY_CHANGE}%)" >&2
+    else
+        log_success "Resource usage within acceptable range" >&2
+    fi
+
+    log_info "" >&2
+    log_info "=========================================" >&2
+
+    # Return current snapshot to stdout for chaining
+    echo "$CURRENT"
+}
+
+# Main
+main() {
+    if [[ "$BASELINE_MODE" == "true" ]]; then
+        capture_metrics
+    elif [[ "$COMPARE_MODE" == "true" ]]; then
+        compare_metrics
+    fi
+}
+
+main

--- a/scripts/compare-metrics.sh
+++ b/scripts/compare-metrics.sh
@@ -40,6 +40,10 @@ VERBOSE=false
 PROMETHEUS_NAMESPACE="openshift-customer-monitoring"
 PROMETHEUS_POD=""
 
+# Comparison result tracking
+COMPARE_FAILED=0
+COMPARE_WARNINGS=0
+
 # Helper functions
 log_info() {
     echo -e "${NC}$1${NC}" >&2
@@ -51,10 +55,12 @@ log_success() {
 
 log_fail() {
     echo -e "${RED}❌ $1${NC}" >&2
+    COMPARE_FAILED=$((COMPARE_FAILED + 1))
 }
 
 log_warning() {
     echo -e "${YELLOW}⚠️  $1${NC}" >&2
+    COMPARE_WARNINGS=$((COMPARE_WARNINGS + 1))
 }
 
 verbose() {
@@ -171,11 +177,11 @@ capture_metrics() {
     log_info "Capturing metrics snapshot..." >&2
 
     # Find Prometheus pod
-    PROMETHEUS_POD=$(oc get pods -n "$PROMETHEUS_NAMESPACE" -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    PROMETHEUS_POD=$(ocm backplane elevate "$TICKET" -- get pods -n "$PROMETHEUS_NAMESPACE" -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
 
     # If not found, might be named prometheus-app-sre
     if [[ -z "$PROMETHEUS_POD" ]]; then
-        PROMETHEUS_POD=$(oc get pods -n "$PROMETHEUS_NAMESPACE" -l prometheus=app-sre -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+        PROMETHEUS_POD=$(ocm backplane elevate "$TICKET" -- get pods -n "$PROMETHEUS_NAMESPACE" -l prometheus=app-sre -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
     fi
 
     if [[ -z "$PROMETHEUS_POD" ]]; then
@@ -314,8 +320,8 @@ compare_metrics() {
     fi
 
     # Reconcile latency
-    RECONCILE_P95_CHANGE=$(awk -v c="$C_RECONCILE_P95" -v b="$B_RECONCILE_P95" 'BEGIN { printf "%.2f", (c - b) / b * 100 }')
-    RECONCILE_P99_CHANGE=$(awk -v c="$C_RECONCILE_P99" -v b="$B_RECONCILE_P99" 'BEGIN { printf "%.2f", (c - b) / b * 100 }')
+    RECONCILE_P95_CHANGE=$(awk -v c="$C_RECONCILE_P95" -v b="$B_RECONCILE_P95" 'BEGIN { if (b > 0) printf "%.2f", (c - b) / b * 100; else print "0" }')
+    RECONCILE_P99_CHANGE=$(awk -v c="$C_RECONCILE_P99" -v b="$B_RECONCILE_P99" 'BEGIN { if (b > 0) printf "%.2f", (c - b) / b * 100; else print "0" }')
 
     log_info "" >&2
     log_info "Reconciliation Latency:" >&2
@@ -356,6 +362,13 @@ compare_metrics() {
 
     # Return current snapshot to stdout for chaining
     echo "$CURRENT"
+
+    if [[ "$COMPARE_FAILED" -gt 0 ]]; then
+        return 2
+    elif [[ "$COMPARE_WARNINGS" -gt 0 ]]; then
+        return 1
+    fi
+    return 0
 }
 
 # Main

--- a/scripts/validate-deployment.sh
+++ b/scripts/validate-deployment.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# validate-deployment.sh - Validate pagerduty-operator deployment health
+#
+# Usage: ./validate-deployment.sh [OPTIONS]
+#
+# Options:
+#   -n, --namespace NAMESPACE    Operator namespace (default: pagerduty-operator)
+#   -t, --ticket TICKET          SREP ticket URL for elevation (required)
+#   -j, --json                   Output results in JSON format
+#   -v, --verbose                Verbose output
+#   -h, --help                   Show this help message
+#
+# Prerequisites:
+#   - Must be logged into the hive cluster with oc
+#   - Must have ocm backplane access
+#   - Must provide SREP ticket for elevation
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Default values
+NAMESPACE="pagerduty-operator"
+TICKET=""
+JSON_OUTPUT=false
+VERBOSE=false
+
+# Results tracking
+CHECKS_PASSED=0
+CHECKS_FAILED=0
+CHECKS_WARNING=0
+RESULTS=()
+
+# Helper functions
+log_info() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${NC}$1${NC}"
+    fi
+}
+
+log_success() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${GREEN}✅ $1${NC}"
+    fi
+    CHECKS_PASSED=$((CHECKS_PASSED + 1))
+    RESULTS+=("{\"check\":\"$2\",\"status\":\"pass\",\"message\":\"$1\"}")
+}
+
+log_fail() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${RED}❌ $1${NC}"
+    fi
+    CHECKS_FAILED=$((CHECKS_FAILED + 1))
+    RESULTS+=("{\"check\":\"$2\",\"status\":\"fail\",\"message\":\"$1\"}")
+}
+
+log_warning() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${YELLOW}⚠️  $1${NC}"
+    fi
+    CHECKS_WARNING=$((CHECKS_WARNING + 1))
+    RESULTS+=("{\"check\":\"$2\",\"status\":\"warning\",\"message\":\"$1\"}")
+}
+
+verbose() {
+    if [[ "$VERBOSE" == "true" && "$JSON_OUTPUT" == "false" ]]; then
+        echo "  → $1"
+    fi
+}
+
+show_help() {
+    grep '^#' "$0" | grep -v '#!/bin/bash' | sed 's/^# //' | sed 's/^#//'
+    exit 0
+}
+
+# Elevated oc command wrapper
+elevated_oc() {
+    ocm backplane elevate "$TICKET" -- "$@" 2>/dev/null
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -n|--namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        -t|--ticket)
+            TICKET="$2"
+            shift 2
+            ;;
+        -j|--json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "$TICKET" ]]; then
+    echo "Error: SREP ticket URL is required (-t|--ticket)" >&2
+    echo "" >&2
+    show_help
+fi
+
+# Main validation logic
+main() {
+    log_info "Starting pagerduty-operator deployment validation"
+    log_info "Namespace: $NAMESPACE"
+    log_info ""
+
+    # Check 1: Verify we're logged into a cluster
+    log_info "[1/5] Verifying cluster connection..."
+    if ! oc whoami &>/dev/null; then
+        log_fail "Not logged into a cluster. Please login with 'oc login' first." "cluster_connection"
+        exit 1
+    fi
+    CLUSTER=$(oc whoami --show-server)
+    verbose "Connected to: $CLUSTER"
+    log_success "Connected to cluster" "cluster_connection"
+
+    # Check 2: Verify namespace exists
+    log_info "[2/5] Verifying namespace exists..."
+    if ! elevated_oc get namespace "$NAMESPACE" &>/dev/null; then
+        log_fail "Namespace '$NAMESPACE' does not exist" "namespace_exists"
+        exit 1
+    fi
+    log_success "Namespace '$NAMESPACE' exists" "namespace_exists"
+
+    # Check 3: Check pod status
+    log_info "[3/5] Checking pod status..."
+    POD_STATUS=$(elevated_oc get pods -n "$NAMESPACE" -l name=pagerduty-operator -o json 2>/dev/null || echo "{}")
+
+    if [[ "$POD_STATUS" == "{}" ]] || [[ $(echo "$POD_STATUS" | jq -r '.items | length') -eq 0 ]]; then
+        log_fail "No pagerduty-operator pods found" "pod_exists"
+    else
+        POD_COUNT=$(echo "$POD_STATUS" | jq -r '.items | length')
+        verbose "Found $POD_COUNT pod(s)"
+
+        RUNNING_PODS=0
+        for i in $(seq 0 $((POD_COUNT - 1))); do
+            POD_NAME=$(echo "$POD_STATUS" | jq -r ".items[$i].metadata.name")
+            POD_PHASE=$(echo "$POD_STATUS" | jq -r ".items[$i].status.phase")
+            RESTART_COUNT=$(echo "$POD_STATUS" | jq -r ".items[$i].status.containerStatuses[0].restartCount // 0")
+            POD_IMAGE=$(echo "$POD_STATUS" | jq -r ".items[$i].status.containerStatuses[0].imageID // \"unknown\"" | sed 's/.*@//')
+
+            verbose "Pod: $POD_NAME | Phase: $POD_PHASE | Restarts: $RESTART_COUNT"
+            verbose "Image: $POD_IMAGE"
+
+            if [[ "$POD_PHASE" != "Running" ]]; then
+                log_fail "Pod $POD_NAME is not Running (phase: $POD_PHASE)" "pod_running"
+            else
+                RUNNING_PODS=$((RUNNING_PODS + 1))
+                if [[ "$RESTART_COUNT" -gt 0 ]]; then
+                    log_warning "Pod $POD_NAME has $RESTART_COUNT restart(s)" "pod_restarts"
+                else
+                    log_success "Pod $POD_NAME is Running with 0 restarts" "pod_health"
+                fi
+            fi
+        done
+
+        if [[ $RUNNING_PODS -eq $POD_COUNT ]]; then
+            log_success "All $POD_COUNT pod(s) are Running" "pods_running"
+        fi
+    fi
+
+    # Check 4: Check for ERROR logs
+    log_info "[4/5] Checking for ERROR-level logs..."
+    verbose "Scanning pod logs for errors..."
+    ERROR_LOGS=$(elevated_oc logs -n "$NAMESPACE" -l name=pagerduty-operator 2>/dev/null | grep '"level":"error"' || echo "")
+
+    if [[ -z "$ERROR_LOGS" ]]; then
+        log_success "No ERROR-level logs found" "error_logs"
+    else
+        ERROR_COUNT=$(echo "$ERROR_LOGS" | wc -l)
+
+        # Check if errors are all benign (namespace terminating)
+        BENIGN_COUNT=$(echo "$ERROR_LOGS" | grep "is being terminated" | wc -l)
+
+        if [[ "$BENIGN_COUNT" -eq "$ERROR_COUNT" ]]; then
+            log_warning "Found $ERROR_COUNT ERROR log(s), all benign (namespace terminating)" "error_logs"
+        else
+            NON_BENIGN=$((ERROR_COUNT - BENIGN_COUNT))
+            log_warning "Found $ERROR_COUNT ERROR log(s) ($NON_BENIGN non-benign)" "error_logs"
+        fi
+
+        if [[ "$VERBOSE" == "true" ]]; then
+            verbose "Most recent errors (last 10):"
+            echo "$ERROR_LOGS" | tail -10 | while read -r line; do
+                verbose "  $line"
+            done
+        fi
+    fi
+
+    # Check 5: Verify deployment exists and desired replicas
+    log_info "[5/5] Checking deployment configuration..."
+    DEPLOYMENT=$(elevated_oc get deployment -n "$NAMESPACE" pagerduty-operator -o json 2>/dev/null || echo "{}")
+
+    if [[ "$DEPLOYMENT" == "{}" ]]; then
+        log_fail "Deployment 'pagerduty-operator' not found" "deployment_exists"
+    else
+        DESIRED=$(echo "$DEPLOYMENT" | jq -r '.spec.replicas')
+        AVAILABLE=$(echo "$DEPLOYMENT" | jq -r '.status.availableReplicas // 0')
+        READY=$(echo "$DEPLOYMENT" | jq -r '.status.readyReplicas // 0')
+
+        verbose "Desired: $DESIRED | Available: $AVAILABLE | Ready: $READY"
+
+        if [[ "$AVAILABLE" -eq "$DESIRED" && "$READY" -eq "$DESIRED" ]]; then
+            log_success "Deployment has $DESIRED/$DESIRED replicas available and ready" "deployment_replicas"
+        else
+            log_fail "Deployment replica mismatch - Desired: $DESIRED, Available: $AVAILABLE, Ready: $READY" "deployment_replicas"
+        fi
+    fi
+
+    # Summary
+    log_info ""
+    log_info "========================================="
+    log_info "Validation Summary"
+    log_info "========================================="
+
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        echo "{"
+        echo "  \"namespace\": \"$NAMESPACE\","
+        echo "  \"cluster\": \"$CLUSTER\","
+        echo "  \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
+        echo "  \"summary\": {"
+        echo "    \"passed\": $CHECKS_PASSED,"
+        echo "    \"failed\": $CHECKS_FAILED,"
+        echo "    \"warnings\": $CHECKS_WARNING"
+        echo "  },"
+        echo "  \"checks\": ["
+        echo "    $(IFS=,; echo "${RESULTS[*]}")"
+        echo "  ]"
+        echo "}"
+    else
+        log_info "Passed:   $CHECKS_PASSED"
+        log_info "Failed:   $CHECKS_FAILED"
+        log_info "Warnings: $CHECKS_WARNING"
+        log_info ""
+
+        if [[ $CHECKS_FAILED -gt 0 ]]; then
+            log_fail "Validation FAILED - $CHECKS_FAILED critical issues found" "overall"
+            exit 1
+        elif [[ $CHECKS_WARNING -gt 0 ]]; then
+            log_warning "Validation PASSED with $CHECKS_WARNING warning(s)" "overall"
+            exit 0
+        else
+            log_success "Validation PASSED - All checks successful" "overall"
+            exit 0
+        fi
+    fi
+}
+
+main

--- a/scripts/validate-deployment.sh
+++ b/scripts/validate-deployment.sh
@@ -125,7 +125,7 @@ main() {
     log_info ""
 
     # Check 1: Verify we're logged into a cluster
-    log_info "[1/5] Verifying cluster connection..."
+    log_info "[1/8] Verifying cluster connection..."
     if ! oc whoami &>/dev/null; then
         log_fail "Not logged into a cluster. Please login with 'oc login' first." "cluster_connection"
         exit 1
@@ -135,15 +135,51 @@ main() {
     log_success "Connected to cluster" "cluster_connection"
 
     # Check 2: Verify namespace exists
-    log_info "[2/5] Verifying namespace exists..."
+    log_info "[2/8] Verifying namespace exists..."
     if ! elevated_oc get namespace "$NAMESPACE" &>/dev/null; then
         log_fail "Namespace '$NAMESPACE' does not exist" "namespace_exists"
         exit 1
     fi
     log_success "Namespace '$NAMESPACE' exists" "namespace_exists"
 
-    # Check 3: Check pod status
-    log_info "[3/5] Checking pod status..."
+    # Check 3: ClusterPackage status (PKO deployment)
+    log_info "[3/8] Checking ClusterPackage status..."
+    CP_JSON=$(elevated_oc get clusterpackage pagerduty-operator -o json 2>/dev/null || echo "{}")
+
+    if [[ "$CP_JSON" == "{}" ]]; then
+        log_warning "ClusterPackage 'pagerduty-operator' not found (may be OLM-deployed)" "clusterpackage_exists"
+    else
+        CP_PKO_IMAGE=$(echo "$CP_JSON" | jq -r '.spec.image // "unknown"')
+        CP_OPERATOR_IMAGE=$(echo "$CP_JSON" | jq -r '.spec.config.image // "unknown"')
+        CP_OPERATOR_TAG=$(echo "$CP_OPERATOR_IMAGE" | sed 's/.*://')
+        CP_GENERATION=$(echo "$CP_JSON" | jq -r '.metadata.generation')
+        CP_OBSERVED=$(echo "$CP_JSON" | jq -r '.status.conditions[] | select(.type == "Available") | .observedGeneration // 0')
+        CP_AVAILABLE=$(echo "$CP_JSON" | jq -r '.status.conditions[] | select(.type == "Available") | .status')
+        CP_PROGRESSING=$(echo "$CP_JSON" | jq -r '.status.conditions[] | select(.type == "Progressing") | .status')
+        CP_UNPACKED=$(echo "$CP_JSON" | jq -r '.status.conditions[] | select(.type == "Unpacked") | .status')
+        CP_UPDATE_TIME=$(echo "$CP_JSON" | jq -r '.metadata.annotations["qontract.update"] // "unknown"')
+
+        verbose "PKO image: $CP_PKO_IMAGE"
+        verbose "Operator image: $CP_OPERATOR_IMAGE"
+        verbose "Generation: $CP_GENERATION | Observed: $CP_OBSERVED"
+        verbose "Unpacked: $CP_UNPACKED | Available: $CP_AVAILABLE | Progressing: $CP_PROGRESSING"
+        verbose "Last SAAS update: $CP_UPDATE_TIME"
+
+        if [[ "$CP_AVAILABLE" == "True" && "$CP_PROGRESSING" == "False" && "$CP_UNPACKED" == "True" ]]; then
+            log_success "ClusterPackage healthy (operator image: $CP_OPERATOR_TAG, updated: $CP_UPDATE_TIME)" "clusterpackage_status"
+        elif [[ "$CP_PROGRESSING" == "True" ]]; then
+            log_warning "ClusterPackage update in progress (target: $CP_OPERATOR_TAG)" "clusterpackage_status"
+        else
+            log_fail "ClusterPackage unhealthy (Available=$CP_AVAILABLE, Unpacked=$CP_UNPACKED, Progressing=$CP_PROGRESSING)" "clusterpackage_status"
+        fi
+
+        if [[ "$CP_GENERATION" != "$CP_OBSERVED" ]]; then
+            log_warning "ClusterPackage generation mismatch (current: $CP_GENERATION, observed: $CP_OBSERVED) — update may be pending" "clusterpackage_generation"
+        fi
+    fi
+
+    # Check 4: Check pod status and image commit
+    log_info "[4/8] Checking pod status..."
     POD_STATUS=$(elevated_oc get pods -n "$NAMESPACE" -l name=pagerduty-operator -o json 2>/dev/null || echo "{}")
 
     if [[ "$POD_STATUS" == "{}" ]] || [[ $(echo "$POD_STATUS" | jq -r '.items | length') -eq 0 ]]; then
@@ -157,7 +193,8 @@ main() {
             POD_NAME=$(echo "$POD_STATUS" | jq -r ".items[$i].metadata.name")
             POD_PHASE=$(echo "$POD_STATUS" | jq -r ".items[$i].status.phase")
             RESTART_COUNT=$(echo "$POD_STATUS" | jq -r ".items[$i].status.containerStatuses[0].restartCount // 0")
-            POD_IMAGE=$(echo "$POD_STATUS" | jq -r ".items[$i].status.containerStatuses[0].imageID // \"unknown\"" | sed 's/.*@//')
+            POD_IMAGE=$(echo "$POD_STATUS" | jq -r ".items[$i].spec.containers[0].image // \"unknown\"")
+            POD_IMAGE_TAG=$(echo "$POD_IMAGE" | sed 's/.*://')
 
             verbose "Pod: $POD_NAME | Phase: $POD_PHASE | Restarts: $RESTART_COUNT"
             verbose "Image: $POD_IMAGE"
@@ -169,7 +206,7 @@ main() {
                 if [[ "$RESTART_COUNT" -gt 0 ]]; then
                     log_warning "Pod $POD_NAME has $RESTART_COUNT restart(s)" "pod_restarts"
                 else
-                    log_success "Pod $POD_NAME is Running with 0 restarts" "pod_health"
+                    log_success "Pod $POD_NAME is Running with 0 restarts (image: $POD_IMAGE_TAG)" "pod_health"
                 fi
             fi
         done
@@ -177,10 +214,61 @@ main() {
         if [[ $RUNNING_PODS -eq $POD_COUNT ]]; then
             log_success "All $POD_COUNT pod(s) are Running" "pods_running"
         fi
+
+        # Verify pod image matches ClusterPackage spec
+        if [[ -n "${CP_OPERATOR_IMAGE:-}" && "$CP_OPERATOR_IMAGE" != "unknown" ]]; then
+            RUNNING_IMAGE=$(echo "$POD_STATUS" | jq -r '[.items[] | select(.status.phase == "Running")] | first | .spec.containers[0].image // "unknown"')
+            if [[ "$RUNNING_IMAGE" == "$CP_OPERATOR_IMAGE" ]]; then
+                log_success "Pod image matches ClusterPackage spec ($POD_IMAGE_TAG)" "image_consistency"
+            else
+                RUNNING_TAG=$(echo "$RUNNING_IMAGE" | sed 's/.*://')
+                log_warning "Pod image ($RUNNING_TAG) does not match ClusterPackage spec ($CP_OPERATOR_TAG) — rollout may be in progress" "image_consistency"
+            fi
+        fi
     fi
 
-    # Check 4: Check for ERROR logs
-    log_info "[4/5] Checking for ERROR-level logs..."
+    # Check 5: ReplicaSet rollout state
+    log_info "[5/8] Checking ReplicaSet rollout state..."
+    RS_JSON=$(elevated_oc get replicaset -n "$NAMESPACE" -l name=pagerduty-operator -o json 2>/dev/null || echo '{"items":[]}')
+    RS_COUNT=$(echo "$RS_JSON" | jq -r '.items | length')
+
+    if [[ "$RS_COUNT" -eq 0 ]]; then
+        verbose "No ReplicaSets found (checking without label selector)"
+        RS_JSON=$(elevated_oc get replicaset -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+        RS_COUNT=$(echo "$RS_JSON" | jq -r '.items | length')
+    fi
+
+    if [[ "$RS_COUNT" -gt 0 ]]; then
+        ACTIVE_RS=0
+        STALE_RS=0
+        for i in $(seq 0 $((RS_COUNT - 1))); do
+            RS_NAME=$(echo "$RS_JSON" | jq -r ".items[$i].metadata.name")
+            RS_DESIRED=$(echo "$RS_JSON" | jq -r ".items[$i].spec.replicas // 0")
+            RS_READY=$(echo "$RS_JSON" | jq -r ".items[$i].status.readyReplicas // 0")
+            RS_IMAGE=$(echo "$RS_JSON" | jq -r ".items[$i].spec.template.spec.containers[0].image // \"unknown\"" | sed 's/.*://')
+
+            if [[ "$RS_DESIRED" -gt 0 ]]; then
+                ACTIVE_RS=$((ACTIVE_RS + 1))
+                verbose "Active RS: $RS_NAME (image: $RS_IMAGE, $RS_READY/$RS_DESIRED ready)"
+            else
+                STALE_RS=$((STALE_RS + 1))
+                verbose "Scaled-down RS: $RS_NAME (image: $RS_IMAGE)"
+            fi
+        done
+
+        if [[ "$ACTIVE_RS" -eq 1 ]]; then
+            log_success "Clean rollout state: 1 active ReplicaSet, $STALE_RS previous" "replicaset_state"
+        elif [[ "$ACTIVE_RS" -gt 1 ]]; then
+            log_warning "Rollout in progress: $ACTIVE_RS active ReplicaSets (expected 1)" "replicaset_state"
+        else
+            log_fail "No active ReplicaSets found" "replicaset_state"
+        fi
+    else
+        verbose "No ReplicaSets found"
+    fi
+
+    # Check 6: Check for ERROR logs
+    log_info "[6/8] Checking for ERROR-level logs..."
     verbose "Scanning pod logs for errors..."
     ERROR_LOGS=$(elevated_oc logs -n "$NAMESPACE" -l name=pagerduty-operator 2>/dev/null | grep '"level":"error"' || echo "")
 
@@ -207,8 +295,8 @@ main() {
         fi
     fi
 
-    # Check 5: Verify deployment exists and desired replicas
-    log_info "[5/5] Checking deployment configuration..."
+    # Check 7: Verify deployment exists and desired replicas
+    log_info "[7/8] Checking deployment configuration..."
     DEPLOYMENT=$(elevated_oc get deployment -n "$NAMESPACE" pagerduty-operator -o json 2>/dev/null || echo "{}")
 
     if [[ "$DEPLOYMENT" == "{}" ]]; then
@@ -225,6 +313,23 @@ main() {
         else
             log_fail "Deployment replica mismatch - Desired: $DESIRED, Available: $AVAILABLE, Ready: $READY" "deployment_replicas"
         fi
+    fi
+
+    # Check 8: Detect image pull failures (SAAS deploy raced Konflux build)
+    log_info "[8/8] Checking for image pull issues..."
+    PULL_PROBLEMS=$(echo "$POD_STATUS" | jq -r '[.items[] | select(
+        .status.containerStatuses[0].state.waiting.reason == "ErrImagePull" or
+        .status.containerStatuses[0].state.waiting.reason == "ImagePullBackOff"
+    )] | length' 2>/dev/null || echo "0")
+
+    if [[ "$PULL_PROBLEMS" -gt 0 ]]; then
+        PROBLEM_IMAGES=$(echo "$POD_STATUS" | jq -r '[.items[] | select(
+            .status.containerStatuses[0].state.waiting.reason == "ErrImagePull" or
+            .status.containerStatuses[0].state.waiting.reason == "ImagePullBackOff"
+        ) | .spec.containers[0].image] | unique | .[]' | sed 's/.*://')
+        log_fail "Image pull failure detected — SAAS deploy may have raced the Konflux build (image: $PROBLEM_IMAGES)" "image_pull"
+    else
+        log_success "No image pull issues" "image_pull"
     fi
 
     # Summary

--- a/scripts/validate-deployment.sh
+++ b/scripts/validate-deployment.sh
@@ -352,6 +352,9 @@ main() {
         echo "    $(IFS=,; echo "${RESULTS[*]}")"
         echo "  ]"
         echo "}"
+        if [[ $CHECKS_FAILED -gt 0 ]]; then
+            exit 1
+        fi
     else
         log_info "Passed:   $CHECKS_PASSED"
         log_info "Failed:   $CHECKS_FAILED"

--- a/scripts/validate-deployment.sh
+++ b/scripts/validate-deployment.sh
@@ -153,10 +153,10 @@ main() {
         CP_OPERATOR_IMAGE=$(echo "$CP_JSON" | jq -r '.spec.config.image // "unknown"')
         CP_OPERATOR_TAG=$(echo "$CP_OPERATOR_IMAGE" | sed 's/.*://')
         CP_GENERATION=$(echo "$CP_JSON" | jq -r '.metadata.generation')
-        CP_OBSERVED=$(echo "$CP_JSON" | jq -r '.status.conditions[] | select(.type == "Available") | .observedGeneration // 0')
-        CP_AVAILABLE=$(echo "$CP_JSON" | jq -r '.status.conditions[] | select(.type == "Available") | .status')
-        CP_PROGRESSING=$(echo "$CP_JSON" | jq -r '.status.conditions[] | select(.type == "Progressing") | .status')
-        CP_UNPACKED=$(echo "$CP_JSON" | jq -r '.status.conditions[] | select(.type == "Unpacked") | .status')
+        CP_OBSERVED=$(echo "$CP_JSON" | jq -r '[(.status.conditions // [])[] | select(.type == "Available")] | first | .observedGeneration // 0')
+        CP_AVAILABLE=$(echo "$CP_JSON" | jq -r '[(.status.conditions // [])[] | select(.type == "Available")] | first | .status // "Unknown"')
+        CP_PROGRESSING=$(echo "$CP_JSON" | jq -r '[(.status.conditions // [])[] | select(.type == "Progressing")] | first | .status // "Unknown"')
+        CP_UNPACKED=$(echo "$CP_JSON" | jq -r '[(.status.conditions // [])[] | select(.type == "Unpacked")] | first | .status // "Unknown"')
         CP_UPDATE_TIME=$(echo "$CP_JSON" | jq -r '.metadata.annotations["qontract.update"] // "unknown"')
 
         verbose "PKO image: $CP_PKO_IMAGE"

--- a/scripts/validate-functional.sh
+++ b/scripts/validate-functional.sh
@@ -1,0 +1,590 @@
+#!/bin/bash
+# validate-functional.sh - Validate pagerduty-operator functional behavior
+#
+# Focuses on clusters installed AFTER the operator pod started, to prove
+# the current version is actively creating PagerDuty resources correctly.
+#
+# Validates:
+#   - PagerDutyIntegration CRs exist and have finalizers
+#   - Operator pod start time (rollout timestamp)
+#   - ClusterDeployments installed after rollout have PD finalizers
+#   - Those clusters have ConfigMaps (*-pd-config) with SERVICE_ID/INTEGRATION_ID
+#   - Those clusters have Secrets (*-pd-secret) (existence only, content NOT read)
+#   - Those clusters have SyncSets (*-pd-secret) with valid structure
+#   - Logs show successful reconciliation and heartbeat activity
+#   - If no new clusters since rollout, reports clearly
+#
+# All resource checks are scoped to specific CD namespaces, not cluster-wide.
+#
+# Usage: ./validate-functional.sh [OPTIONS]
+#
+# Options:
+#   -n, --namespace NAMESPACE    Operator namespace (default: pagerduty-operator)
+#   -t, --ticket TICKET          SREP ticket URL for elevation (required)
+#   -j, --json                   Output results in JSON format
+#   -v, --verbose                Verbose output
+#   -h, --help                   Show this help message
+#
+# Prerequisites:
+#   - Must be logged into the hive cluster with oc
+#   - Must have ocm backplane access
+#   - Must provide SREP ticket for elevation
+#
+# Note: This script is READ-ONLY and does not modify any resources
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default values
+NAMESPACE="pagerduty-operator"
+TICKET=""
+JSON_OUTPUT=false
+VERBOSE=false
+
+# Results tracking
+CHECKS_PASSED=0
+CHECKS_FAILED=0
+CHECKS_WARNING=0
+RESULTS=()
+
+# Helper functions
+log_info() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${NC}$1${NC}"
+    fi
+}
+
+log_success() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${GREEN}✅ $1${NC}"
+    fi
+    CHECKS_PASSED=$((CHECKS_PASSED + 1))
+    RESULTS+=("{\"check\":\"$2\",\"status\":\"pass\",\"message\":\"$1\",\"value\":\"$3\"}")
+}
+
+log_fail() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${RED}❌ $1${NC}"
+    fi
+    CHECKS_FAILED=$((CHECKS_FAILED + 1))
+    RESULTS+=("{\"check\":\"$2\",\"status\":\"fail\",\"message\":\"$1\",\"value\":\"$3\"}")
+}
+
+log_warning() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${YELLOW}⚠️  $1${NC}"
+    fi
+    CHECKS_WARNING=$((CHECKS_WARNING + 1))
+    RESULTS+=("{\"check\":\"$2\",\"status\":\"warning\",\"message\":\"$1\",\"value\":\"$3\"}")
+}
+
+log_action() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${BLUE}🔵 $1${NC}"
+    fi
+}
+
+verbose() {
+    if [[ "$VERBOSE" == "true" && "$JSON_OUTPUT" == "false" ]]; then
+        echo "  → $1"
+    fi
+}
+
+show_help() {
+    grep '^#' "$0" | grep -v '#!/bin/bash' | sed 's/^# //' | sed 's/^#//'
+    exit 0
+}
+
+# Elevated oc command wrapper
+elevated_oc() {
+    ocm backplane elevate "$TICKET" -- "$@" 2>/dev/null
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -n|--namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        -t|--ticket)
+            TICKET="$2"
+            shift 2
+            ;;
+        -j|--json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "$TICKET" ]]; then
+    echo "Error: SREP ticket URL is required (-t|--ticket)" >&2
+    echo "" >&2
+    show_help
+fi
+
+# Main validation logic
+main() {
+    log_info "Starting pagerduty-operator functional validation"
+    log_info "Namespace: $NAMESPACE"
+    log_info ""
+
+    # ------------------------------------------------------------------
+    # Check 1: Verify cluster connection
+    # ------------------------------------------------------------------
+    log_info "[1/7] Verifying cluster connection..."
+    if ! oc whoami &>/dev/null; then
+        log_fail "Not logged into a cluster" "cluster_connection" "N/A"
+        exit 1
+    fi
+    log_success "Connected to cluster" "cluster_connection" "$(oc whoami --show-server)"
+
+    # ------------------------------------------------------------------
+    # Check 2: PagerDutyIntegration CRs
+    # ------------------------------------------------------------------
+    log_info "[2/7] Checking PagerDutyIntegration resources..."
+    PDI_JSON=$(elevated_oc get pagerdutyintegration -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+    PDI_COUNT=$(echo "$PDI_JSON" | jq -r '.items | length')
+
+    if [[ "$PDI_COUNT" -eq 0 ]]; then
+        log_fail "No PagerDutyIntegration resources found" "pdi_exists" "0"
+    else
+        # Collect service prefixes for resource lookups
+        PDI_PREFIXES=()
+        for i in $(seq 0 $((PDI_COUNT - 1))); do
+            PDI_NAME=$(echo "$PDI_JSON" | jq -r ".items[$i].metadata.name")
+            PDI_FINALIZERS=$(echo "$PDI_JSON" | jq -r ".items[$i].metadata.finalizers // [] | length")
+            PDI_PREFIX=$(echo "$PDI_JSON" | jq -r ".items[$i].spec.servicePrefix")
+            PDI_SELECTOR=$(echo "$PDI_JSON" | jq -c ".items[$i].spec.clusterDeploymentSelector")
+            PDI_PREFIXES+=("$PDI_PREFIX")
+
+            verbose "PDI: $PDI_NAME | prefix: $PDI_PREFIX | selector: $PDI_SELECTOR | finalizers: $PDI_FINALIZERS"
+
+            if [[ "$PDI_FINALIZERS" -gt 0 ]]; then
+                log_success "PDI '$PDI_NAME' has finalizer (active, prefix: $PDI_PREFIX)" "pdi_finalizer_$PDI_NAME" "$PDI_FINALIZERS"
+            else
+                log_warning "PDI '$PDI_NAME' has no finalizers" "pdi_finalizer_$PDI_NAME" "0"
+            fi
+        done
+    fi
+
+    # ------------------------------------------------------------------
+    # Check 3: Determine operator rollout time
+    # ------------------------------------------------------------------
+    log_info "[3/7] Determining operator rollout time..."
+    POD_JSON=$(elevated_oc get pods -n "$NAMESPACE" -l name=pagerduty-operator -o json 2>/dev/null || echo '{"items":[]}')
+    POD_COUNT=$(echo "$POD_JSON" | jq -r '.items | length')
+
+    if [[ "$POD_COUNT" -eq 0 ]]; then
+        log_fail "No operator pods found" "operator_pod" "0"
+        exit 1
+    fi
+
+    # Use the oldest running pod's start time as rollout timestamp
+    POD_START=$(echo "$POD_JSON" | jq -r '[.items[] | select(.status.phase == "Running") | .status.startTime] | sort | first // "unknown"')
+    POD_NAME=$(echo "$POD_JSON" | jq -r '.items[0].metadata.name')
+    POD_IMAGE=$(echo "$POD_JSON" | jq -r '.items[0].status.containerStatuses[0].image // "unknown"' | sed 's|.*/||')
+
+    if [[ "$POD_START" == "unknown" || "$POD_START" == "null" ]]; then
+        log_fail "Could not determine operator pod start time" "pod_start_time" "unknown"
+        exit 1
+    fi
+
+    POD_START_EPOCH=$(date -d "$POD_START" +%s 2>/dev/null || echo "0")
+    POD_AGE_HOURS=$(( ($(date +%s) - POD_START_EPOCH) / 3600 ))
+    POD_AGE_MINS=$(( (($(date +%s) - POD_START_EPOCH) % 3600) / 60 ))
+
+    log_success "Operator pod started: $POD_START (${POD_AGE_HOURS}h${POD_AGE_MINS}m ago, image: $POD_IMAGE)" "pod_start_time" "$POD_START"
+
+    # ------------------------------------------------------------------
+    # Check 4: Find ClusterDeployments installed AFTER operator rollout
+    # ------------------------------------------------------------------
+    log_info "[4/7] Finding ClusterDeployments installed after operator rollout..."
+
+    # Query ClusterDeployments directly — they are the source of truth
+    # for which namespaces contain PD resources
+    CD_JSON=$(elevated_oc get clusterdeployment.hive.openshift.io --all-namespaces -o json 2>/dev/null || echo '{"items":[]}')
+    CD_TOTAL=$(echo "$CD_JSON" | jq -r '.items | length')
+    CD_INSTALLED=$(echo "$CD_JSON" | jq -r '[.items[] | select(.spec.installed == true)] | length')
+
+    # Collect unique namespaces where CDs live (for scoped resource lookups later)
+    CD_NAMESPACES=$(echo "$CD_JSON" | jq -r '[.items[].metadata.namespace] | unique | .[]')
+
+    # Filter CDs installed after pod start time
+    NEW_CDS=$(echo "$CD_JSON" | jq -r --arg since "$POD_START" \
+        '[.items[] | select(.spec.installed == true) |
+          select(
+            (.status.installedTimestamp // .metadata.creationTimestamp) > $since
+          )]')
+    NEW_CD_COUNT=$(echo "$NEW_CDS" | jq -r 'length')
+
+    verbose "Total CDs: $CD_TOTAL | Installed: $CD_INSTALLED | Installed after rollout: $NEW_CD_COUNT"
+
+    if [[ "$CD_TOTAL" -eq 0 ]]; then
+        log_action "No ClusterDeployments found on this hive — no PD resources expected"
+    fi
+
+    if [[ "$NEW_CD_COUNT" -eq 0 ]]; then
+        log_action "NO new clusters installed since operator rollout ($POD_START)"
+        log_action "Cannot validate new PD service creation with current version"
+        log_action "Options:"
+        log_action "  1. Wait for a cluster to be provisioned on this hive"
+        log_action "  2. Request a test cluster creation"
+        log_action "  3. Re-run this script later"
+        log_warning "No new clusters to validate since rollout" "new_clusters" "0"
+    else
+        log_success "Found $NEW_CD_COUNT cluster(s) installed after operator rollout" "new_clusters" "$NEW_CD_COUNT"
+    fi
+
+    # ------------------------------------------------------------------
+    # Check 5: Spot-check PD resources for new clusters
+    # ------------------------------------------------------------------
+    if [[ "$NEW_CD_COUNT" -gt 0 ]]; then
+        # Filter to eligible CDs before spot-checking (exclude fake/nightly/noalerts)
+        ELIGIBLE_FOR_SPOT=$(echo "$NEW_CDS" | jq -r '[.[] |
+            select((.metadata.annotations["managed.openshift.com/fake"] // "false") != "true") |
+            select((.metadata.labels["api.openshift.com/channel-group"] // "") != "nightly") |
+            select((.metadata.labels["api.openshift.com/noalerts"] // "") != "true") |
+            select((.metadata.labels["ext-managed.openshift.io/noalerts"] // "") != "true")]
+            | sort_by(.status.installedTimestamp // .metadata.creationTimestamp)')
+        ELIGIBLE_FOR_SPOT_COUNT=$(echo "$ELIGIBLE_FOR_SPOT" | jq -r 'length')
+
+        if [[ "$ELIGIBLE_FOR_SPOT_COUNT" -eq 0 ]]; then
+            log_info "[5/7] Skipping PD resource validation (all $NEW_CD_COUNT new clusters are fake/nightly/noalerts)"
+            SPOT_COUNT=0
+        else
+            if [[ "$ELIGIBLE_FOR_SPOT_COUNT" -le 2 ]]; then
+                SPOT_CHECK_CDS="$ELIGIBLE_FOR_SPOT"
+                SPOT_COUNT="$ELIGIBLE_FOR_SPOT_COUNT"
+            else
+                FIRST=$(echo "$ELIGIBLE_FOR_SPOT" | jq '.[0]')
+                MIDDLE=$(echo "$ELIGIBLE_FOR_SPOT" | jq ".[$(( ELIGIBLE_FOR_SPOT_COUNT / 2 ))]")
+                LAST=$(echo "$ELIGIBLE_FOR_SPOT" | jq '.[-1]')
+                SPOT_CHECK_CDS=$(echo "[$FIRST,$MIDDLE,$LAST]" | jq -r '.')
+                SPOT_COUNT=3
+            fi
+
+            log_info "[5/7] Spot-checking PD resources for $SPOT_COUNT of $ELIGIBLE_FOR_SPOT_COUNT eligible new cluster(s)..."
+            log_info "       (Note: secret existence is checked but content is NOT read or decoded)"
+        fi
+
+        VALIDATED=0
+        VALIDATION_FAILURES=0
+
+        for i in $(seq 0 $((SPOT_COUNT - 1))); do
+            CD_NAME=$(echo "$SPOT_CHECK_CDS" | jq -r ".[$i].metadata.name")
+            CD_NS=$(echo "$SPOT_CHECK_CDS" | jq -r ".[$i].metadata.namespace")
+            CD_INSTALLED_TIME=$(echo "$SPOT_CHECK_CDS" | jq -r ".[$i].status.installedTimestamp // .[$i].metadata.creationTimestamp")
+
+            verbose "Validating cluster: $CD_NS/$CD_NAME (installed: $CD_INSTALLED_TIME)"
+
+            # Check PD finalizer on this CD (from already-fetched data)
+            HAS_PD_FINALIZER=$(echo "$SPOT_CHECK_CDS" | jq -r ".[$i].metadata.finalizers // [] | map(select(startswith(\"pd.managed.openshift.io/\"))) | length")
+
+            # Bulk fetch all ConfigMaps, Secrets, SyncSets from this namespace in one call
+            NS_RESOURCES=$(elevated_oc get configmap,secret,syncset -n "$CD_NS" -o json 2>/dev/null || echo '{"items":[]}')
+
+            # Validate PD resources locally
+            CM_FOUND=false
+            SECRET_FOUND=false
+            SS_FOUND=false
+            CM_VALID=false
+            SS_VALID=false
+
+            for PREFIX in "${PDI_PREFIXES[@]}"; do
+                CM_NAME_CHECK="${PREFIX}-${CD_NAME}-pd-config"
+                SECRET_NAME_CHECK="${PREFIX}-${CD_NAME}-pd-secret"
+
+                # ConfigMap - find by name and kind in bulk data
+                CM_DATA=$(echo "$NS_RESOURCES" | jq -r --arg name "$CM_NAME_CHECK" '.items[] | select(.kind == "ConfigMap" and .metadata.name == $name) // empty')
+                if [[ -z "$CM_DATA" ]]; then
+                    continue
+                fi
+
+                CM_FOUND=true
+                verbose "  Matched PDI prefix: $PREFIX"
+                SVC_ID=$(echo "$CM_DATA" | jq -r '.data.SERVICE_ID // ""')
+                INT_ID=$(echo "$CM_DATA" | jq -r '.data.INTEGRATION_ID // ""')
+                ESC_ID=$(echo "$CM_DATA" | jq -r '.data.ESCALATION_POLICY_ID // ""')
+                if [[ -n "$SVC_ID" && -n "$INT_ID" && -n "$ESC_ID" ]]; then
+                    CM_VALID=true
+                    verbose "  ConfigMap $CM_NAME_CHECK: SERVICE_ID=$SVC_ID INTEGRATION_ID=$INT_ID ESCALATION_POLICY_ID=$ESC_ID"
+                else
+                    verbose "  ConfigMap $CM_NAME_CHECK: MISSING keys (SERVICE_ID='$SVC_ID' INTEGRATION_ID='$INT_ID' ESCALATION_POLICY_ID='$ESC_ID')"
+                fi
+
+                # Secret - check existence only (NOT reading content)
+                verbose "  Secret $SECRET_NAME_CHECK: checking existence only (not reading content)"
+                SECRET_EXISTS=$(echo "$NS_RESOURCES" | jq -r --arg name "$SECRET_NAME_CHECK" '.items[] | select(.kind == "Secret" and .metadata.name == $name) | .metadata.name // empty')
+                if [[ -n "$SECRET_EXISTS" ]]; then
+                    SECRET_FOUND=true
+                    verbose "  Secret $SECRET_NAME_CHECK: exists"
+                fi
+
+                # SyncSet - validate structure
+                SS_DATA=$(echo "$NS_RESOURCES" | jq -r --arg name "$SECRET_NAME_CHECK" '.items[] | select(.kind == "SyncSet" and .metadata.name == $name) // empty')
+                if [[ -n "$SS_DATA" ]]; then
+                    SS_FOUND=true
+                    SS_CD_REF=$(echo "$SS_DATA" | jq -r '.spec.clusterDeploymentRefs[0].name // ""')
+                    SS_APPLY_MODE=$(echo "$SS_DATA" | jq -r '.spec.resourceApplyMode // ""')
+                    SS_MAPPING_COUNT=$(echo "$SS_DATA" | jq -r '.spec.secretMappings | length // 0')
+                    SS_SOURCE_NAME=$(echo "$SS_DATA" | jq -r '.spec.secretMappings[0].sourceRef.name // ""')
+                    SS_TARGET_NAME=$(echo "$SS_DATA" | jq -r '.spec.secretMappings[0].targetRef.name // ""')
+                    SS_TARGET_NS=$(echo "$SS_DATA" | jq -r '.spec.secretMappings[0].targetRef.namespace // ""')
+
+                    if [[ "$SS_CD_REF" == "$CD_NAME" && "$SS_APPLY_MODE" == "Sync" && "$SS_MAPPING_COUNT" -gt 0 && -n "$SS_TARGET_NAME" && -n "$SS_TARGET_NS" ]]; then
+                        SS_VALID=true
+                        verbose "  SyncSet $SECRET_NAME_CHECK: valid (CD ref=$SS_CD_REF, mode=$SS_APPLY_MODE, source=$SS_SOURCE_NAME, target=$SS_TARGET_NS/$SS_TARGET_NAME)"
+                    else
+                        verbose "  SyncSet $SECRET_NAME_CHECK: INVALID (CD ref='$SS_CD_REF' expected '$CD_NAME', mode='$SS_APPLY_MODE', mappings=$SS_MAPPING_COUNT, target='$SS_TARGET_NS/$SS_TARGET_NAME')"
+                    fi
+                fi
+
+                break
+            done
+
+            # Report results for this cluster
+            if [[ "$HAS_PD_FINALIZER" -gt 0 ]]; then
+                verbose "  PD finalizer: present"
+            else
+                verbose "  PD finalizer: MISSING"
+            fi
+
+            if $CM_FOUND && $CM_VALID && $SECRET_FOUND && $SS_FOUND && $SS_VALID && [[ "$HAS_PD_FINALIZER" -gt 0 ]]; then
+                log_success "Cluster $CD_NS/$CD_NAME: all PD resources present and valid" "new_cd_$CD_NAME" "complete"
+                VALIDATED=$((VALIDATED + 1))
+            else
+                MISSING=""
+                [[ "$HAS_PD_FINALIZER" -eq 0 ]] && MISSING="${MISSING}finalizer,"
+                $CM_FOUND || MISSING="${MISSING}configmap,"
+                $CM_VALID || MISSING="${MISSING}configmap-data,"
+                $SECRET_FOUND || MISSING="${MISSING}secret,"
+                $SS_FOUND || MISSING="${MISSING}syncset,"
+                $SS_VALID || MISSING="${MISSING}syncset-data,"
+                MISSING="${MISSING%,}"
+
+                log_fail "Cluster $CD_NS/$CD_NAME: missing [$MISSING]" "new_cd_$CD_NAME" "$MISSING"
+                VALIDATION_FAILURES=$((VALIDATION_FAILURES + 1))
+            fi
+        done
+
+        if [[ "$VALIDATION_FAILURES" -eq 0 && "$VALIDATED" -gt 0 ]]; then
+            log_success "All $VALIDATED spot-checked cluster(s) have complete PD resources" "new_cluster_validation" "$VALIDATED/$VALIDATED"
+        elif [[ "$VALIDATED" -gt 0 ]]; then
+            log_warning "$VALIDATED/$((VALIDATED + VALIDATION_FAILURES)) spot-checked cluster(s) have complete PD resources" "new_cluster_validation" "$VALIDATED/$((VALIDATED + VALIDATION_FAILURES))"
+        fi
+    else
+        log_info "[5/7] Skipping PD resource validation (no new clusters)"
+    fi
+
+    # ------------------------------------------------------------------
+    # Check 6: PD finalizer counts across all new clusters (from cached data)
+    # ------------------------------------------------------------------
+    log_info "[6/7] Checking PD finalizers across all new cluster(s)..."
+
+    if [[ "$NEW_CD_COUNT" -gt 0 ]]; then
+        # Filter out clusters that are excluded from PD by design (no API calls needed)
+        # - Fake clusters (managed.openshift.com/fake annotation)
+        # - Nightly channel clusters (channel-group: nightly)
+        # - Clusters with noalerts labels
+        # - FedRAMP clusters (handled by separate PDI, but excluded from standard ones)
+        ELIGIBLE_CDS=$(echo "$NEW_CDS" | jq -r '[.[] |
+            select((.metadata.annotations["managed.openshift.com/fake"] // "false") != "true") |
+            select((.metadata.labels["api.openshift.com/channel-group"] // "") != "nightly") |
+            select((.metadata.labels["api.openshift.com/noalerts"] // "") != "true") |
+            select((.metadata.labels["ext-managed.openshift.io/noalerts"] // "") != "true")]')
+        ELIGIBLE_COUNT=$(echo "$ELIGIBLE_CDS" | jq -r 'length')
+        FILTERED_COUNT=$((NEW_CD_COUNT - ELIGIBLE_COUNT))
+
+        if [[ "$FILTERED_COUNT" -gt 0 ]]; then
+            log_info "       (filtering $FILTERED_COUNT cluster(s): fake/nightly/noalerts)"
+        fi
+
+        ELIGIBLE_WITH_FINALIZER=$(echo "$ELIGIBLE_CDS" | jq -r '[.[] | select(.metadata.finalizers != null) | select(.metadata.finalizers[] | startswith("pd.managed.openshift.io/"))] | length')
+        ELIGIBLE_WITHOUT_FINALIZER=$((ELIGIBLE_COUNT - ELIGIBLE_WITH_FINALIZER))
+
+        if [[ "$ELIGIBLE_COUNT" -eq 0 ]]; then
+            verbose "No eligible clusters after filtering (all $NEW_CD_COUNT are fake/nightly/noalerts)"
+        elif [[ "$ELIGIBLE_WITHOUT_FINALIZER" -eq 0 ]]; then
+            log_success "All $ELIGIBLE_COUNT eligible new cluster(s) have PD finalizers" "new_cd_finalizers" "$ELIGIBLE_WITH_FINALIZER/$ELIGIBLE_COUNT"
+        else
+            log_warning "$ELIGIBLE_WITHOUT_FINALIZER of $ELIGIBLE_COUNT eligible new cluster(s) missing PD finalizers" "new_cd_finalizers" "$ELIGIBLE_WITH_FINALIZER/$ELIGIBLE_COUNT"
+            # List the clusters missing finalizers for SRE investigation
+            MISSING_FINALIZER_CDS=$(echo "$ELIGIBLE_CDS" | jq -r '[.[] |
+                select(
+                    (.metadata.finalizers == null) or
+                    ([.metadata.finalizers[] | select(startswith("pd.managed.openshift.io/"))] | length == 0)
+                )]')
+            MISSING_COUNT=$(echo "$MISSING_FINALIZER_CDS" | jq -r 'length')
+            for j in $(seq 0 $((MISSING_COUNT - 1))); do
+                MISS_NS=$(echo "$MISSING_FINALIZER_CDS" | jq -r ".[$j].metadata.namespace")
+                MISS_NAME=$(echo "$MISSING_FINALIZER_CDS" | jq -r ".[$j].metadata.name")
+                MISS_DEL=$(echo "$MISSING_FINALIZER_CDS" | jq -r ".[$j].metadata.deletionTimestamp // empty")
+                if [[ -n "$MISS_DEL" ]]; then
+                    log_info "       - $MISS_NS/$MISS_NAME (deleting: $MISS_DEL)"
+                else
+                    log_info "       - $MISS_NS/$MISS_NAME (not deleting)"
+                fi
+            done
+        fi
+    else
+        verbose "No new clusters to check finalizers for"
+    fi
+
+    # ------------------------------------------------------------------
+    # Check 7: Log activity (single fetch, heartbeat + errors + creation evidence)
+    # ------------------------------------------------------------------
+    log_info "[7/7] Checking log activity..."
+    RECENT_LOGS=$(elevated_oc logs -n "$NAMESPACE" -l name=pagerduty-operator --tail=200 2>/dev/null || echo "")
+
+    if [[ -z "$RECENT_LOGS" ]]; then
+        log_warning "Could not retrieve operator logs" "recent_activity" "no logs"
+    else
+        # Heartbeat
+        HEARTBEAT_LINES=$(echo "$RECENT_LOGS" | grep "Metrics for PD API" | wc -l)
+        if [[ "$HEARTBEAT_LINES" -gt 0 ]]; then
+            LAST_HEARTBEAT=$(echo "$RECENT_LOGS" | grep "Metrics for PD API" | tail -1 | jq -r '.ts' 2>/dev/null || echo "unknown")
+            log_success "PD API heartbeat active (last: $LAST_HEARTBEAT)" "heartbeat_logs" "$HEARTBEAT_LINES"
+        else
+            log_fail "No PD API heartbeat found in recent logs" "heartbeat_logs" "0"
+        fi
+
+        # Successful reconciliations
+        RECONCILE_LINES=$(echo "$RECENT_LOGS" | grep "Successfully reconciled" | wc -l)
+        if [[ "$RECONCILE_LINES" -gt 0 ]]; then
+            LAST_RECONCILE=$(echo "$RECENT_LOGS" | grep "Successfully reconciled" | tail -1 | jq -r '.ts' 2>/dev/null || echo "unknown")
+            log_success "Recent successful reconciliations ($RECONCILE_LINES, last: $LAST_RECONCILE)" "reconcile_activity" "$RECONCILE_LINES"
+        else
+            verbose "No 'Successfully reconciled' messages in recent logs (may be normal if no changes)"
+        fi
+
+        # Errors
+        ERROR_LINES=$(echo "$RECENT_LOGS" | grep '"level":"error"' | wc -l)
+        if [[ "$ERROR_LINES" -gt 0 ]]; then
+            BENIGN_ERRORS=$(echo "$RECENT_LOGS" | grep '"level":"error"' | grep "is being terminated" | wc -l)
+            NON_BENIGN=$((ERROR_LINES - BENIGN_ERRORS))
+            if [[ "$NON_BENIGN" -gt 0 ]]; then
+                log_warning "Found $NON_BENIGN non-benign error(s) in recent logs" "recent_errors" "$NON_BENIGN"
+                if [[ "$VERBOSE" == "true" ]]; then
+                    echo "$RECENT_LOGS" | grep '"level":"error"' | grep -v "is being terminated" | tail -5 | while read -r line; do
+                        verbose "  $line"
+                    done
+                fi
+            else
+                verbose "Found $ERROR_LINES error(s) in recent logs, all benign (namespace terminating)"
+            fi
+        fi
+
+        # Creation evidence for spot-checked clusters (from same log fetch)
+        if [[ "$NEW_CD_COUNT" -gt 0 ]]; then
+            CREATE_EVIDENCE=0
+            for i in $(seq 0 $((SPOT_COUNT - 1))); do
+                CD_NAME=$(echo "$SPOT_CHECK_CDS" | jq -r ".[$i].metadata.name")
+                CD_NS=$(echo "$SPOT_CHECK_CDS" | jq -r ".[$i].metadata.namespace")
+
+                CLUSTER_LOGS=$(echo "$RECENT_LOGS" | grep "$CD_NS" || echo "")
+                if [[ -n "$CLUSTER_LOGS" ]]; then
+                    PD_SECRET_LOG=$(echo "$CLUSTER_LOGS" | grep "creating pd secret" | wc -l)
+                    RECONCILE_LOG=$(echo "$CLUSTER_LOGS" | grep "Successfully reconciled" | wc -l)
+
+                    if [[ "$PD_SECRET_LOG" -gt 0 || "$RECONCILE_LOG" -gt 0 ]]; then
+                        verbose "Cluster $CD_NS/$CD_NAME: found creation log evidence (secret_create=$PD_SECRET_LOG, reconciled=$RECONCILE_LOG)"
+                        CREATE_EVIDENCE=$((CREATE_EVIDENCE + 1))
+                    else
+                        verbose "Cluster $CD_NS/$CD_NAME: no creation evidence in recent logs (may have rotated)"
+                    fi
+                else
+                    verbose "Cluster $CD_NS/$CD_NAME: no log entries in recent logs (may have rotated)"
+                fi
+            done
+
+            if [[ "$CREATE_EVIDENCE" -gt 0 ]]; then
+                log_success "Found creation evidence in logs for $CREATE_EVIDENCE of $SPOT_COUNT spot-checked cluster(s)" "creation_logs" "$CREATE_EVIDENCE"
+            else
+                verbose "No creation evidence in recent logs for spot-checked clusters (logs may have rotated)"
+            fi
+        fi
+    fi
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    log_info ""
+    log_info "========================================="
+    log_info "Functional Validation Summary"
+    log_info "========================================="
+
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        echo "{"
+        echo "  \"namespace\": \"$NAMESPACE\","
+        echo "  \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
+        echo "  \"operator_start\": \"$POD_START\","
+        echo "  \"operator_image\": \"$POD_IMAGE\","
+        echo "  \"summary\": {"
+        echo "    \"passed\": $CHECKS_PASSED,"
+        echo "    \"failed\": $CHECKS_FAILED,"
+        echo "    \"warnings\": $CHECKS_WARNING,"
+        echo "    \"pdi_count\": $PDI_COUNT,"
+        echo "    \"clusterdeployment_total\": $CD_TOTAL,"
+        echo "    \"clusterdeployment_installed\": $CD_INSTALLED,"
+        echo "    \"new_clusters_since_rollout\": $NEW_CD_COUNT,"
+        echo "    \"pd_configmaps_total\": $PD_CM_TOTAL,"
+        echo "    \"pd_secrets_total\": $PD_SECRET_TOTAL,"
+        echo "    \"pd_syncsets_total\": $PD_SS_TOTAL"
+        echo "  },"
+        echo "  \"checks\": ["
+        echo "    $(IFS=,; echo "${RESULTS[*]}")"
+        echo "  ]"
+        echo "}"
+    else
+        log_info "Passed:   $CHECKS_PASSED"
+        log_info "Failed:   $CHECKS_FAILED"
+        log_info "Warnings: $CHECKS_WARNING"
+        log_info ""
+        log_info "Operator: $POD_IMAGE (started $POD_START)"
+        log_info ""
+        log_info "Resources:"
+        log_info "  PagerDutyIntegrations:        $PDI_COUNT"
+        log_info "  ClusterDeployments:           $CD_TOTAL (installed: $CD_INSTALLED)"
+        log_info "  New clusters since rollout:   $NEW_CD_COUNT"
+        log_info "  Total PD ConfigMaps:          $PD_CM_TOTAL"
+        log_info "  Total PD Secrets:             $PD_SECRET_TOTAL (existence only)"
+        log_info "  Total PD SyncSets:            $PD_SS_TOTAL"
+        log_info ""
+
+        if [[ $CHECKS_FAILED -gt 0 ]]; then
+            log_fail "Functional validation FAILED - $CHECKS_FAILED critical issues found" "overall" "N/A"
+            exit 1
+        elif [[ "$NEW_CD_COUNT" -eq 0 ]]; then
+            log_warning "Functional validation INCOMPLETE - no new clusters to validate since rollout" "overall" "N/A"
+            exit 0
+        elif [[ $CHECKS_WARNING -gt 0 ]]; then
+            log_warning "Functional validation PASSED with $CHECKS_WARNING warning(s)" "overall" "N/A"
+            exit 0
+        else
+            log_success "Functional validation PASSED - All checks successful" "overall" "N/A"
+            exit 0
+        fi
+    fi
+}
+
+main

--- a/scripts/validate-functional.sh
+++ b/scripts/validate-functional.sh
@@ -561,6 +561,9 @@ main() {
         echo "    $(IFS=,; echo "${RESULTS[*]}")"
         echo "  ]"
         echo "}"
+        if [[ $CHECKS_FAILED -gt 0 ]]; then
+            exit 1
+        fi
     else
         log_info "Passed:   $CHECKS_PASSED"
         log_info "Failed:   $CHECKS_FAILED"

--- a/scripts/validate-functional.sh
+++ b/scripts/validate-functional.sh
@@ -52,6 +52,9 @@ CHECKS_PASSED=0
 CHECKS_FAILED=0
 CHECKS_WARNING=0
 RESULTS=()
+PD_CM_TOTAL=0
+PD_SECRET_TOTAL=0
+PD_SS_TOTAL=0
 
 # Helper functions
 log_info() {
@@ -199,8 +202,8 @@ main() {
         exit 1
     fi
 
-    # Use the oldest running pod's start time as rollout timestamp
-    POD_START=$(echo "$POD_JSON" | jq -r '[.items[] | select(.status.phase == "Running") | .status.startTime] | sort | first // "unknown"')
+    # Use the newest running pod's start time as rollout timestamp
+    POD_START=$(echo "$POD_JSON" | jq -r '[.items[] | select(.status.phase == "Running") | .status.startTime] | sort | last // "unknown"')
     POD_NAME=$(echo "$POD_JSON" | jq -r '.items[0].metadata.name')
     POD_IMAGE=$(echo "$POD_JSON" | jq -r '.items[0].status.containerStatuses[0].image // "unknown"' | sed 's|.*/||')
 
@@ -321,6 +324,7 @@ main() {
                 fi
 
                 CM_FOUND=true
+                PD_CM_TOTAL=$((PD_CM_TOTAL + 1))
                 verbose "  Matched PDI prefix: $PREFIX"
                 SVC_ID=$(echo "$CM_DATA" | jq -r '.data.SERVICE_ID // ""')
                 INT_ID=$(echo "$CM_DATA" | jq -r '.data.INTEGRATION_ID // ""')
@@ -337,6 +341,7 @@ main() {
                 SECRET_EXISTS=$(echo "$NS_RESOURCES" | jq -r --arg name "$SECRET_NAME_CHECK" '.items[] | select(.kind == "Secret" and .metadata.name == $name) | .metadata.name // empty')
                 if [[ -n "$SECRET_EXISTS" ]]; then
                     SECRET_FOUND=true
+                    PD_SECRET_TOTAL=$((PD_SECRET_TOTAL + 1))
                     verbose "  Secret $SECRET_NAME_CHECK: exists"
                 fi
 
@@ -344,6 +349,7 @@ main() {
                 SS_DATA=$(echo "$NS_RESOURCES" | jq -r --arg name "$SECRET_NAME_CHECK" '.items[] | select(.kind == "SyncSet" and .metadata.name == $name) // empty')
                 if [[ -n "$SS_DATA" ]]; then
                     SS_FOUND=true
+                    PD_SS_TOTAL=$((PD_SS_TOTAL + 1))
                     SS_CD_REF=$(echo "$SS_DATA" | jq -r '.spec.clusterDeploymentRefs[0].name // ""')
                     SS_APPLY_MODE=$(echo "$SS_DATA" | jq -r '.spec.resourceApplyMode // ""')
                     SS_MAPPING_COUNT=$(echo "$SS_DATA" | jq -r '.spec.secretMappings | length // 0')

--- a/scripts/validate.mk
+++ b/scripts/validate.mk
@@ -1,0 +1,83 @@
+SCRIPTS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+REASON ?=
+NAMESPACE ?= pagerduty-operator
+BASELINE_DIR ?= /tmp/baselines
+VERBOSE ?= -v
+
+# Hive cluster info from ocm backplane status (lazy-evaluated)
+HIVE_NAME = $(shell ocm backplane status 2>/dev/null | awk '/Cluster Name:/ {print $$NF}')
+HIVE_ID = $(shell ocm backplane status 2>/dev/null | awk '/Cluster ID:/ {print $$NF}')
+
+default: validate
+
+.PHONY: check-reason check-cluster help
+.PHONY: baseline compare validate validate-deployment validate-functional validate-metrics
+
+help: ## Show this help
+	@echo "PagerDuty Operator Validation"
+	@echo ""
+	@echo "Prerequisites:"
+	@echo "  - Must be logged into a hive cluster via ocm backplane"
+	@echo "  - REASON must be set to a Jira ticket URL for elevation"
+	@echo ""
+	@echo "Usage:"
+	@echo "  make -f scripts/validate.mk <target> REASON=https://redhat.atlassian.net/browse/SREP-XXXX"
+	@echo ""
+	@echo "Targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-25s %s\n", $$1, $$2}'
+
+check-reason:
+ifndef REASON
+	$(error REASON is required. Set REASON to a Jira ticket URL, e.g. REASON=https://redhat.atlassian.net/browse/SREP-XXXX)
+endif
+
+check-cluster:
+	@oc whoami --show-server >/dev/null 2>&1 || (echo "ERROR: Not logged into a cluster. Run 'ocm backplane login <hive>' first." && exit 1)
+	@echo "Logged into: $(HIVE_ID) - $(HIVE_NAME)"
+
+# --- Baseline targets ---
+
+baseline: check-reason check-cluster ## Capture metrics baseline for current hive (saves to BASELINE_DIR)
+	@mkdir -p $(BASELINE_DIR)
+	@echo "Capturing baseline for $(HIVE_NAME)..."
+	@bash $(SCRIPTS_DIR)/compare-metrics.sh --baseline -t "$(REASON)" $(VERBOSE) > $(BASELINE_DIR)/baseline-$(HIVE_NAME)-$(shell date +%Y%m%d).json
+	@echo "Baseline saved to: $(BASELINE_DIR)/baseline-$(HIVE_NAME)-$(shell date +%Y%m%d).json"
+
+# --- Compare target ---
+
+compare: check-reason check-cluster ## Compare current metrics against baseline (set BASELINE=<file>)
+ifndef BASELINE
+	$(error BASELINE is required. Set BASELINE to a baseline JSON file, e.g. BASELINE=/tmp/baselines/baseline-hive-stage-01-20260318.json)
+endif
+	bash $(SCRIPTS_DIR)/compare-metrics.sh --compare "$(BASELINE)" -t "$(REASON)" $(VERBOSE)
+
+# --- Validation targets ---
+
+validate-deployment: check-reason check-cluster ## Validate operator deployment health
+	bash $(SCRIPTS_DIR)/validate-deployment.sh -t "$(REASON)" $(VERBOSE)
+
+validate-functional: check-reason check-cluster ## Validate operator functional behavior (PD resources for new clusters)
+	bash $(SCRIPTS_DIR)/validate-functional.sh -t "$(REASON)" $(VERBOSE)
+
+validate-metrics: check-reason check-cluster ## Validate operator Prometheus metrics
+	bash $(SCRIPTS_DIR)/check-metrics.sh -t "$(REASON)" $(VERBOSE)
+
+validate: check-reason check-cluster ## Run all three validations (deployment, functional, metrics)
+	@echo "========================================="
+	@echo "PagerDuty Operator Validation Suite"
+	@echo "Cluster: $(HIVE_ID) - $(HIVE_NAME)"
+	@echo "Reason:  $(REASON)"
+	@echo "========================================="
+	@echo ""
+	@echo "--- Deployment Validation ---"
+	@bash $(SCRIPTS_DIR)/validate-deployment.sh -t "$(REASON)" $(VERBOSE) || true
+	@echo ""
+	@echo "--- Functional Validation ---"
+	@bash $(SCRIPTS_DIR)/validate-functional.sh -t "$(REASON)" $(VERBOSE) || true
+	@echo ""
+	@echo "--- Metrics Validation ---"
+	@bash $(SCRIPTS_DIR)/check-metrics.sh -t "$(REASON)" $(VERBOSE) || true
+	@echo ""
+	@echo "========================================="
+	@echo "Validation complete."
+	@echo "========================================="

--- a/scripts/validate.mk
+++ b/scripts/validate.mk
@@ -27,7 +27,7 @@ help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-25s %s\n", $$1, $$2}'
 
 check-reason:
-ifndef REASON
+ifeq ($(strip $(REASON)),)
 	$(error REASON is required. Set REASON to a Jira ticket URL, e.g. REASON=https://redhat.atlassian.net/browse/SREP-XXXX)
 endif
 
@@ -70,13 +70,13 @@ validate: check-reason check-cluster ## Run all three validations (deployment, f
 	@echo "========================================="
 	@echo ""
 	@echo "--- Deployment Validation ---"
-	@bash $(SCRIPTS_DIR)/validate-deployment.sh -t "$(REASON)" $(VERBOSE) || true
+	@bash $(SCRIPTS_DIR)/validate-deployment.sh -t "$(REASON)" $(VERBOSE)
 	@echo ""
 	@echo "--- Functional Validation ---"
-	@bash $(SCRIPTS_DIR)/validate-functional.sh -t "$(REASON)" $(VERBOSE) || true
+	@bash $(SCRIPTS_DIR)/validate-functional.sh -t "$(REASON)" $(VERBOSE)
 	@echo ""
 	@echo "--- Metrics Validation ---"
-	@bash $(SCRIPTS_DIR)/check-metrics.sh -t "$(REASON)" $(VERBOSE) || true
+	@bash $(SCRIPTS_DIR)/check-metrics.sh -t "$(REASON)" $(VERBOSE)
 	@echo ""
 	@echo "========================================="
 	@echo "Validation complete."

--- a/scripts/validation-suite.sh
+++ b/scripts/validation-suite.sh
@@ -1,0 +1,357 @@
+#!/bin/bash
+# validation-suite.sh - Run complete validation suite for pagerduty-operator
+#
+# Usage: ./validation-suite.sh [OPTIONS]
+#
+# Options:
+#   -e, --environment ENV        Environment (integration|staging|production)
+#   -n, --namespace NAMESPACE    Operator namespace (default: pagerduty-operator)
+#   -t, --ticket TICKET          SREP ticket number for elevation (required)
+#   -b, --baseline FILE          Optional baseline file for metrics comparison
+#   -s, --skip CHECKS            Comma-separated list of checks to skip (deployment,metrics,functional)
+#   -j, --json                   Output results in JSON format
+#   -v, --verbose                Verbose output
+#   -h, --help                   Show this help message
+#
+# Prerequisites:
+#   - Must be logged into the hive cluster with oc
+#   - Must have ocm backplane access for metrics validation
+#   - Must provide SREP ticket for elevation
+#
+# Note: This script is READ-ONLY and does not modify any resources
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default values
+ENVIRONMENT=""
+NAMESPACE="pagerduty-operator"
+TICKET=""
+BASELINE_FILE=""
+SKIP_CHECKS=""
+JSON_OUTPUT=false
+VERBOSE=false
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Results tracking
+DEPLOYMENT_STATUS="PENDING"
+METRICS_STATUS="PENDING"
+FUNCTIONAL_STATUS="PENDING"
+OVERALL_STATUS="PENDING"
+
+# Helper functions
+log_info() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${NC}$1${NC}"
+    fi
+}
+
+log_success() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${GREEN}✅ $1${NC}"
+    fi
+}
+
+log_fail() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${RED}❌ $1${NC}"
+    fi
+}
+
+log_warning() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${YELLOW}⚠️  $1${NC}"
+    fi
+}
+
+log_header() {
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        echo -e "${BLUE}=========================================${NC}"
+        echo -e "${BLUE}$1${NC}"
+        echo -e "${BLUE}=========================================${NC}"
+    fi
+}
+
+verbose() {
+    if [[ "$VERBOSE" == "true" && "$JSON_OUTPUT" == "false" ]]; then
+        echo "  → $1"
+    fi
+}
+
+show_help() {
+    grep '^#' "$0" | grep -v '#!/bin/bash' | sed 's/^# //' | sed 's/^#//'
+    exit 0
+}
+
+# Check if a validation should be skipped
+should_skip() {
+    local check="$1"
+    if [[ "$SKIP_CHECKS" == *"$check"* ]]; then
+        return 0  # True, should skip
+    fi
+    return 1  # False, should not skip
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -e|--environment)
+            ENVIRONMENT="$2"
+            shift 2
+            ;;
+        -n|--namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        -t|--ticket)
+            TICKET="$2"
+            shift 2
+            ;;
+        -b|--baseline)
+            BASELINE_FILE="$2"
+            shift 2
+            ;;
+        -s|--skip)
+            SKIP_CHECKS="$2"
+            shift 2
+            ;;
+        -j|--json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "$TICKET" ]]; then
+    echo "Error: SREP ticket number is required (-t|--ticket)"
+    echo ""
+    show_help
+fi
+
+# Validate environment
+if [[ -n "$ENVIRONMENT" ]]; then
+    case "$ENVIRONMENT" in
+        integration|staging|production)
+            ;;
+        *)
+            echo "Error: Invalid environment. Must be one of: integration, staging, production"
+            exit 1
+            ;;
+    esac
+fi
+
+# Build common args
+COMMON_ARGS="-n $NAMESPACE"
+if [[ "$VERBOSE" == "true" ]]; then
+    COMMON_ARGS="$COMMON_ARGS -v"
+fi
+
+# Main validation logic
+main() {
+    START_TIME=$(date +%s)
+
+    if [[ "$JSON_OUTPUT" == "false" ]]; then
+        log_header "PagerDuty Operator Validation Suite"
+        log_info "Environment:  ${ENVIRONMENT:-Not specified}"
+        log_info "Namespace:    $NAMESPACE"
+        log_info "SREP Ticket:  $TICKET"
+        log_info "Cluster:      $(oc whoami --show-server 2>/dev/null || echo 'Not connected')"
+        log_info "Start Time:   $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        log_info ""
+    fi
+
+    # Check 1: Deployment Health
+    if ! should_skip "deployment"; then
+        log_header "1. Deployment Health Check"
+
+        if [[ "$JSON_OUTPUT" == "true" ]]; then
+            DEPLOYMENT_RESULT=$("$SCRIPT_DIR/validate-deployment.sh" $COMMON_ARGS -j 2>&1)
+            DEPLOYMENT_EXIT=$?
+        else
+            "$SCRIPT_DIR/validate-deployment.sh" $COMMON_ARGS
+            DEPLOYMENT_EXIT=$?
+        fi
+
+        if [[ $DEPLOYMENT_EXIT -eq 0 ]]; then
+            DEPLOYMENT_STATUS="PASS"
+            log_success "Deployment health check: PASSED"
+        else
+            DEPLOYMENT_STATUS="FAIL"
+            log_fail "Deployment health check: FAILED"
+        fi
+        log_info ""
+    else
+        DEPLOYMENT_STATUS="SKIPPED"
+        verbose "Skipping deployment health check"
+    fi
+
+    # Check 2: Metrics Validation
+    if ! should_skip "metrics"; then
+        log_header "2. Metrics Validation"
+
+        if [[ "$JSON_OUTPUT" == "true" ]]; then
+            METRICS_RESULT=$("$SCRIPT_DIR/check-metrics.sh" $COMMON_ARGS -t "$TICKET" -j 2>&1)
+            METRICS_EXIT=$?
+        else
+            "$SCRIPT_DIR/check-metrics.sh" $COMMON_ARGS -t "$TICKET"
+            METRICS_EXIT=$?
+        fi
+
+        if [[ $METRICS_EXIT -eq 0 ]]; then
+            METRICS_STATUS="PASS"
+            log_success "Metrics validation: PASSED"
+        else
+            METRICS_STATUS="FAIL"
+            log_fail "Metrics validation: FAILED"
+        fi
+
+        # If baseline provided, compare metrics
+        if [[ -n "$BASELINE_FILE" && -f "$BASELINE_FILE" ]]; then
+            log_info ""
+            log_info "Running metrics comparison against baseline..."
+            "$SCRIPT_DIR/compare-metrics.sh" $COMMON_ARGS -t "$TICKET" -c "$BASELINE_FILE" > /dev/null
+        fi
+
+        log_info ""
+    else
+        METRICS_STATUS="SKIPPED"
+        verbose "Skipping metrics validation"
+    fi
+
+    # Check 3: Functional Validation
+    if ! should_skip "functional"; then
+        log_header "3. Functional Validation"
+
+        if [[ "$JSON_OUTPUT" == "true" ]]; then
+            FUNCTIONAL_RESULT=$("$SCRIPT_DIR/validate-functional.sh" $COMMON_ARGS -j 2>&1)
+            FUNCTIONAL_EXIT=$?
+        else
+            "$SCRIPT_DIR/validate-functional.sh" $COMMON_ARGS
+            FUNCTIONAL_EXIT=$?
+        fi
+
+        if [[ $FUNCTIONAL_EXIT -eq 0 ]]; then
+            FUNCTIONAL_STATUS="PASS"
+            log_success "Functional validation: PASSED"
+        else
+            FUNCTIONAL_STATUS="FAIL"
+            log_fail "Functional validation: FAILED"
+        fi
+        log_info ""
+    else
+        FUNCTIONAL_STATUS="SKIPPED"
+        verbose "Skipping functional validation"
+    fi
+
+    # Overall status
+    if [[ "$DEPLOYMENT_STATUS" == "FAIL" || "$METRICS_STATUS" == "FAIL" || "$FUNCTIONAL_STATUS" == "FAIL" ]]; then
+        OVERALL_STATUS="FAIL"
+    elif [[ "$DEPLOYMENT_STATUS" == "PASS" || "$METRICS_STATUS" == "PASS" || "$FUNCTIONAL_STATUS" == "PASS" ]]; then
+        OVERALL_STATUS="PASS"
+    else
+        OVERALL_STATUS="SKIPPED"
+    fi
+
+    END_TIME=$(date +%s)
+    DURATION=$((END_TIME - START_TIME))
+
+    # Final summary
+    log_header "Validation Summary"
+
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        # Output JSON results
+        cat <<EOF
+{
+  "environment": "${ENVIRONMENT:-unknown}",
+  "namespace": "$NAMESPACE",
+  "cluster": "$(oc whoami --show-server 2>/dev/null || echo 'unknown')",
+  "ticket": "$TICKET",
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "duration_seconds": $DURATION,
+  "overall_status": "$OVERALL_STATUS",
+  "checks": {
+    "deployment": {
+      "status": "$DEPLOYMENT_STATUS",
+      "details": ${DEPLOYMENT_RESULT:-null}
+    },
+    "metrics": {
+      "status": "$METRICS_STATUS",
+      "details": ${METRICS_RESULT:-null}
+    },
+    "functional": {
+      "status": "$FUNCTIONAL_STATUS",
+      "details": ${FUNCTIONAL_RESULT:-null}
+    }
+  }
+}
+EOF
+    else
+        log_info "Deployment Health:      $DEPLOYMENT_STATUS"
+        log_info "Metrics Validation:     $METRICS_STATUS"
+        log_info "Functional Validation:  $FUNCTIONAL_STATUS"
+        log_info ""
+        log_info "Overall Status:         $OVERALL_STATUS"
+        log_info "Duration:               ${DURATION}s"
+        log_info ""
+
+        if [[ "$OVERALL_STATUS" == "PASS" ]]; then
+            log_success "✅ ALL VALIDATIONS PASSED"
+            log_info ""
+            log_info "Next steps for $ENVIRONMENT environment:"
+            case "$ENVIRONMENT" in
+                integration)
+                    log_info "  1. Monitor operator for 1-2 hours"
+                    log_info "  2. Capture baseline metrics: ./compare-metrics.sh --baseline -t TICKET > baseline-integration.json"
+                    log_info "  3. If stable, proceed with promotion to staging"
+                    ;;
+                staging)
+                    log_info "  1. Monitor operator for 24-48 hours"
+                    log_info "  2. Test alert grouping and service orchestration"
+                    log_info "  3. Test limited-support label handling"
+                    log_info "  4. If stable, proceed with promotion to production canary"
+                    ;;
+                production)
+                    log_info "  1. Monitor canary hives (hivep03uw1, hivep04ew2) for 24 hours"
+                    log_info "  2. Compare metrics against baseline"
+                    log_info "  3. Validate real production traffic"
+                    log_info "  4. If stable, proceed with phased rollout to all hives"
+                    ;;
+                *)
+                    log_info "  Review validation results and proceed as appropriate"
+                    ;;
+            esac
+            exit 0
+        else
+            log_fail "❌ VALIDATION FAILED"
+            log_info ""
+            log_info "Recommended actions:"
+            log_info "  1. Review failed checks above"
+            log_info "  2. Check operator logs: oc logs -n $NAMESPACE -l name=pagerduty-operator"
+            log_info "  3. Investigate issues before proceeding"
+            log_info "  4. Consider rollback if in production"
+            exit 1
+        fi
+    fi
+}
+
+main

--- a/scripts/validation-suite.sh
+++ b/scripts/validation-suite.sh
@@ -161,7 +161,7 @@ if [[ -n "$ENVIRONMENT" ]]; then
 fi
 
 # Build common args
-COMMON_ARGS="-n $NAMESPACE"
+COMMON_ARGS="-n $NAMESPACE -t $TICKET"
 if [[ "$VERBOSE" == "true" ]]; then
     COMMON_ARGS="$COMMON_ARGS -v"
 fi
@@ -210,10 +210,10 @@ main() {
         log_header "2. Metrics Validation"
 
         if [[ "$JSON_OUTPUT" == "true" ]]; then
-            METRICS_RESULT=$("$SCRIPT_DIR/check-metrics.sh" $COMMON_ARGS -t "$TICKET" -j 2>&1)
+            METRICS_RESULT=$("$SCRIPT_DIR/check-metrics.sh" $COMMON_ARGS -j 2>&1)
             METRICS_EXIT=$?
         else
-            "$SCRIPT_DIR/check-metrics.sh" $COMMON_ARGS -t "$TICKET"
+            "$SCRIPT_DIR/check-metrics.sh" $COMMON_ARGS
             METRICS_EXIT=$?
         fi
 
@@ -229,7 +229,7 @@ main() {
         if [[ -n "$BASELINE_FILE" && -f "$BASELINE_FILE" ]]; then
             log_info ""
             log_info "Running metrics comparison against baseline..."
-            "$SCRIPT_DIR/compare-metrics.sh" $COMMON_ARGS -t "$TICKET" -c "$BASELINE_FILE" > /dev/null
+            "$SCRIPT_DIR/compare-metrics.sh" $COMMON_ARGS -c "$BASELINE_FILE" > /dev/null
         fi
 
         log_info ""

--- a/scripts/validation-suite.sh
+++ b/scripts/validation-suite.sh
@@ -241,8 +241,9 @@ main() {
         if [[ -n "$BASELINE_FILE" && -f "$BASELINE_FILE" ]]; then
             log_info ""
             log_info "Running metrics comparison against baseline..."
-            if ! "$SCRIPT_DIR/compare-metrics.sh" $COMMON_ARGS -c "$BASELINE_FILE" > /dev/null; then
-                log_warning "Metrics comparison detected regressions"
+            if ! "$SCRIPT_DIR/compare-metrics.sh" $COMMON_ARGS -c "$BASELINE_FILE"; then
+                METRICS_STATUS="WARN"
+                log_warning "Metrics comparison detected regressions (see above)"
             fi
         fi
 
@@ -325,6 +326,9 @@ main() {
   }
 }
 EOF
+        if [[ "$OVERALL_STATUS" == "FAIL" ]]; then
+            exit 1
+        fi
     else
         log_info "Deployment Health:      $DEPLOYMENT_STATUS"
         log_info "Metrics Validation:     $METRICS_STATUS"

--- a/scripts/validation-suite.sh
+++ b/scripts/validation-suite.sh
@@ -185,11 +185,17 @@ main() {
         log_header "1. Deployment Health Check"
 
         if [[ "$JSON_OUTPUT" == "true" ]]; then
-            DEPLOYMENT_RESULT=$("$SCRIPT_DIR/validate-deployment.sh" $COMMON_ARGS -j 2>&1)
-            DEPLOYMENT_EXIT=$?
+            if DEPLOYMENT_RESULT=$("$SCRIPT_DIR/validate-deployment.sh" $COMMON_ARGS -j 2>&1); then
+                DEPLOYMENT_EXIT=0
+            else
+                DEPLOYMENT_EXIT=$?
+            fi
         else
-            "$SCRIPT_DIR/validate-deployment.sh" $COMMON_ARGS
-            DEPLOYMENT_EXIT=$?
+            if "$SCRIPT_DIR/validate-deployment.sh" $COMMON_ARGS; then
+                DEPLOYMENT_EXIT=0
+            else
+                DEPLOYMENT_EXIT=$?
+            fi
         fi
 
         if [[ $DEPLOYMENT_EXIT -eq 0 ]]; then
@@ -210,11 +216,17 @@ main() {
         log_header "2. Metrics Validation"
 
         if [[ "$JSON_OUTPUT" == "true" ]]; then
-            METRICS_RESULT=$("$SCRIPT_DIR/check-metrics.sh" $COMMON_ARGS -j 2>&1)
-            METRICS_EXIT=$?
+            if METRICS_RESULT=$("$SCRIPT_DIR/check-metrics.sh" $COMMON_ARGS -j 2>&1); then
+                METRICS_EXIT=0
+            else
+                METRICS_EXIT=$?
+            fi
         else
-            "$SCRIPT_DIR/check-metrics.sh" $COMMON_ARGS
-            METRICS_EXIT=$?
+            if "$SCRIPT_DIR/check-metrics.sh" $COMMON_ARGS; then
+                METRICS_EXIT=0
+            else
+                METRICS_EXIT=$?
+            fi
         fi
 
         if [[ $METRICS_EXIT -eq 0 ]]; then
@@ -229,7 +241,9 @@ main() {
         if [[ -n "$BASELINE_FILE" && -f "$BASELINE_FILE" ]]; then
             log_info ""
             log_info "Running metrics comparison against baseline..."
-            "$SCRIPT_DIR/compare-metrics.sh" $COMMON_ARGS -c "$BASELINE_FILE" > /dev/null
+            if ! "$SCRIPT_DIR/compare-metrics.sh" $COMMON_ARGS -c "$BASELINE_FILE" > /dev/null; then
+                log_warning "Metrics comparison detected regressions"
+            fi
         fi
 
         log_info ""
@@ -243,11 +257,17 @@ main() {
         log_header "3. Functional Validation"
 
         if [[ "$JSON_OUTPUT" == "true" ]]; then
-            FUNCTIONAL_RESULT=$("$SCRIPT_DIR/validate-functional.sh" $COMMON_ARGS -j 2>&1)
-            FUNCTIONAL_EXIT=$?
+            if FUNCTIONAL_RESULT=$("$SCRIPT_DIR/validate-functional.sh" $COMMON_ARGS -j 2>&1); then
+                FUNCTIONAL_EXIT=0
+            else
+                FUNCTIONAL_EXIT=$?
+            fi
         else
-            "$SCRIPT_DIR/validate-functional.sh" $COMMON_ARGS
-            FUNCTIONAL_EXIT=$?
+            if "$SCRIPT_DIR/validate-functional.sh" $COMMON_ARGS; then
+                FUNCTIONAL_EXIT=0
+            else
+                FUNCTIONAL_EXIT=$?
+            fi
         fi
 
         if [[ $FUNCTIONAL_EXIT -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- Adds validation scripts and Make targets for validating pagerduty-operator rollouts across hive environments
- Scripts are read-only and do not modify cluster or PagerDuty resources
- Secret content is never read or decoded

## Scripts
- `validate-deployment.sh` — ClusterPackage status, pod health, image consistency, ReplicaSet rollout state, restarts, error logs, deployment status, image pull failure detection
- `validate-functional.sh` — spot-checks new clusters for PD ConfigMaps, Secrets, and SyncSets
- `check-metrics.sh` — Prometheus metrics validation (secret_loaded, failures, heartbeat, latency)
- `compare-metrics.sh` — baseline capture and before/after comparison
- `validate.mk` — Make targets for easy invocation with `REASON=<jira-ticket-url>`
- `validation-suite.sh` — orchestrates all validation checks in sequence
- `README.md` — usage documentation and rollout validation workflow

## Usage
```bash
# Run all validations on current hive
make -f scripts/validate.mk validate REASON=https://redhat.atlassian.net/browse/SREP-XXXX

# Capture baseline before promotion
make -f scripts/validate.mk baseline REASON=https://redhat.atlassian.net/browse/SREP-XXXX

# Compare against baseline after promotion
make -f scripts/validate.mk compare REASON=https://redhat.atlassian.net/browse/SREP-XXXX BASELINE=/tmp/baselines/baseline-hive-stage-01-20260318.json
```

## PKO-aware deployment checks (added after real-world validation of PRs 416/417)

During integration validation of PRs #416 and #417 on hivei01ue1, we observed the SAAS deploy pipeline update the ClusterPackage image reference before the Konflux build had pushed the operator image to Quay, causing ~2 minutes of `ErrImagePull`. The old pod remained running (no outage), but the scripts did not detect or report this condition.

Added to `validate-deployment.sh`:
- **ClusterPackage status** — checks PKO conditions (Unpacked/Available/Progressing), operator and PKO image tags, SAAS update timestamp, generation vs observed generation
- **Image consistency** — verifies running pod image matches ClusterPackage spec (detects stale pods during rollout)
- **ReplicaSet rollout state** — reports active vs scaled-down ReplicaSets to detect in-progress or stuck rollouts
- **Image pull failure detection** — catches `ErrImagePull`/`ImagePullBackOff` pods and flags the SAAS-raced-Konflux-build scenario

Fixed in `validation-suite.sh`:
- **Ticket passing** — `-t $TICKET` was not being passed to `validate-deployment.sh` and `validate-functional.sh` sub-scripts, so `elevated_oc` would fail silently

## Test plan
- [x] Tested on hive-stage-01 (77 CDs, 31 new since rollout)
- [x] Tested on hives02ue1 (74 CDs, 21 new since rollout)
- [x] Tested on hives03ue1 (0 CDs — validates empty hive handling)
- [x] Verified spot-check correctly filters fake/nightly/noalerts clusters
- [x] Verified SyncSet structure validation (secretMappings, clusterDeploymentRefs)
- [x] Verified ~1.5 min execution time per hive
- [x] PKO checks validated against live ClusterPackage on hivei01ue1 (integration) during PR 416/417 rollout
- [x] Image pull detection validated against real ErrImagePull event during same rollout
- [x] bash -n syntax validation passes on all modified scripts

REF: https://redhat.atlassian.net/browse/SREP-4075

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only validation suite for the operator: deployment health checks, Prometheus metrics capture/compare, and end-to-end functional PagerDuty checks.
  * Added a Make-based workflow and an orchestration command to run baseline, compare, and sequential validations with per-check PASS/WARN/FAIL reporting.

* **Documentation**
  * Added a comprehensive operator rollout validation guide with quick-start commands, expected outputs (human/JSON), exit codes, and troubleshooting tips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->