### PR TITLE
SREP-3261: Add PKO infrastructure for OLM to PKO migration

### DIFF
--- a/deploy_pko/ConfigMap-osd-serviceorchestration.yaml.gotmpl
+++ b/deploy_pko/ConfigMap-osd-serviceorchestration.yaml.gotmpl
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .config.serviceOrchestrationRuleConfigmap }}
+  namespace: pagerduty-operator
+  labels:
+    api.openshift.com/managed: "true"
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+data:
+  service-orchestration.json: {{ .config.serviceOrchestrationRules | quote }}
+  rh-infra-service-orchestration.json: {{ .config.rhInfraServiceOrchestrationRules | quote }}

--- a/deploy_pko/PagerDutyIntegration-osd-scale-test.yaml.gotmpl
+++ b/deploy_pko/PagerDutyIntegration-osd-scale-test.yaml.gotmpl
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-scale-test
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: {{ .config.acknowledgeTimeout }}
+  resolveTimeout: {{ .config.resolveTimeout }}
+  escalationPolicy: {{ .config.scaleTestEscalationPolicy }}
+  servicePrefix: {{ .config.scaleTestServicePrefix }}
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # select specific organizations
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: {{ toJson .config.scaleTestLegalEntityIds }}
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/PagerDutyIntegration-osd-silent.yaml.gotmpl
+++ b/deploy_pko/PagerDutyIntegration-osd-silent.yaml.gotmpl
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-silent
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: {{ .config.acknowledgeTimeout }}
+  resolveTimeout: {{ .config.resolveTimeout }}
+  escalationPolicy: {{ .config.escalationPolicySilent }}
+  servicePrefix: {{ .config.servicePrefix }}-silent
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: {{ toJson .config.scaleTestLegalEntityIds }}
+    # for the "silent" PDI, create when CD in specific organizations we ignore in the "osd" (regular) PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: {{ toJson .config.silentAlertLegalEntityIds }}
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/PagerDutyIntegration-osd.yaml.gotmpl
+++ b/deploy_pko/PagerDutyIntegration-osd.yaml.gotmpl
@@ -1,0 +1,57 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: {{ .config.acknowledgeTimeout }}
+  resolveTimeout: {{ .config.resolveTimeout }}
+  escalationPolicy: {{ .config.escalationPolicy }}
+  servicePrefix: {{ .config.servicePrefix }}
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  serviceOrchestration:
+    enabled: {{ .config.serviceOrchestrationEnabled }}
+    ruleConfigConfigMapRef:
+      name: {{ .config.serviceOrchestrationRuleConfigmap }}
+      namespace: pagerduty-operator
+  alertGroupingParameters:
+    type: {{ .config.alertGroupingType }}
+    config:
+      timeout: {{ .config.alertGroupingTimeout }}
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: {{ toJson .config.scaleTestLegalEntityIds }}
+    # ignore CD for alerts we wish to route to the silence PD escalation policy
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: {{ toJson .config.silentAlertLegalEntityIds }}
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/PrometheusRule-pagerduty-integration-api-secret.yaml
+++ b/deploy_pko/PrometheusRule-pagerduty-integration-api-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pagerduty-integration-api-secret
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  groups:
+    - name: pagerduty-integration-api-secret
+      rules:
+        - alert: PagerDutyIntegrationAPISecretError
+          annotations:
+            message: PagerDuty Operator is failing to load PAGERDUTY_API_KEY from Secret specified in PagerDutyIntegration {{ $labels.pagerdutyintegration_name }}. Either the Secret might be missing, or the key might be missing from within the Secret.
+          expr: pagerdutyintegration_secret_loaded < 1
+          for: 15m
+          labels:
+            severity: warning

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -10,6 +10,7 @@ spec:
   - name: namespace
   - name: rbac
   - name: deploy
+  - name: integrations
   - name: cleanup-rbac
   - name: cleanup-deploy
   availabilityProbes:
@@ -31,8 +32,67 @@ spec:
         image:
           description: Operator image to deploy
           type: string
-          default: None
+          default: ""
         fedramp:
           description: FedRAMP mode flag
           type: string
           default: "false"
+        acknowledgeTimeout:
+          description: PagerDuty incident acknowledge timeout in seconds
+          type: integer
+          default: 21600
+        resolveTimeout:
+          description: PagerDuty incident resolve timeout in seconds
+          type: integer
+          default: 0
+        escalationPolicy:
+          description: PagerDuty escalation policy ID for standard alerts
+          type: string
+        escalationPolicySilent:
+          description: PagerDuty escalation policy ID for silent alerts
+          type: string
+        servicePrefix:
+          description: Prefix for PagerDuty service names
+          type: string
+        silentAlertLegalEntityIds:
+          description: Legal entity IDs routed to silent escalation policy
+          type: array
+          items:
+            type: string
+          default: []
+        scaleTestEscalationPolicy:
+          description: PagerDuty escalation policy ID for scale test alerts
+          type: string
+        scaleTestServicePrefix:
+          description: Prefix for scale test PagerDuty service names
+          type: string
+        scaleTestLegalEntityIds:
+          description: Legal entity IDs for scale test organizations
+          type: array
+          items:
+            type: string
+          default: []
+        serviceOrchestrationEnabled:
+          description: Enable PagerDuty service orchestration
+          type: string
+          default: "false"
+        serviceOrchestrationRuleConfigmap:
+          description: ConfigMap name containing service orchestration rules
+          type: string
+          default: "osd-serviceorchestration"
+        alertGroupingType:
+          description: PagerDuty alert grouping type
+          type: string
+          default: ""
+        alertGroupingTimeout:
+          description: PagerDuty alert grouping timeout in minutes
+          type: integer
+          default: 0
+        serviceOrchestrationRules:
+          description: JSON rules for PagerDuty service orchestration
+          type: string
+          default: "{}"
+        rhInfraServiceOrchestrationRules:
+          description: JSON rules for RH infra PagerDuty service orchestration
+          type: string
+          default: "{}"

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -11,31 +11,29 @@ parameters:
     required: true
   - name: IMAGE_DIGEST
     required: true
-  - name: NAMESPACE
-    value: pagerduty-operator
   - name: REPO_NAME
     value: pagerduty-operator
     required: true
+  - name: FEDRAMP
+    value: "false"
   - name: ACKNOWLEDGE_TIMEOUT
     required: true
   - name: RESOLVE_TIMEOUT
-    required: true
-  - name: SERVICE_PREFIX
     required: true
   - name: ESCALATION_POLICY
     required: true
   - name: ESCALATION_POLICY_SILENT
     required: true
-  - name: SILENT_ALERT_LEGALENTITY_IDS
-    value: '["None"]'
-  - name: SCALE_TEST_SERVICE_PREFIX
+  - name: SERVICE_PREFIX
     required: true
+  - name: SILENT_ALERT_LEGALENTITY_IDS
+    value: '[]'
   - name: SCALE_TEST_ESCALATION_POLICY
     required: true
+  - name: SCALE_TEST_SERVICE_PREFIX
+    required: true
   - name: SCALE_TEST_LEGALENTITY_IDS
-    value: '["None"]'
-  - name: FEDRAMP
-    value: "false"
+    value: '[]'
   - name: SERVICE_ORCHESTRATION_ENABLED
     value: "false"
   - name: SERVICE_ORCHESTRATION_RULE_CONFIGMAP
@@ -44,6 +42,10 @@ parameters:
     value: ""
   - name: ALERT_GROUPING_TIMEOUT
     value: "0"
+  - name: SERVICE_ORCHESTRATION_RULES
+    value: "{}"
+  - name: RH_INFRA_SERVICE_ORCHESTRATION_RULES
+    value: "{}"
 metadata:
   name: clusterpackage-template
 objects:
@@ -58,139 +60,18 @@ objects:
       config:
         image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
         fedramp: ${FEDRAMP}
-  - apiVersion: pagerduty.openshift.io/v1alpha1
-    kind: PagerDutyIntegration
-    metadata:
-      name: osd
-      namespace: ${NAMESPACE}
-    spec:
-      acknowledgeTimeout: ${{ACKNOWLEDGE_TIMEOUT}}
-      resolveTimeout: ${{RESOLVE_TIMEOUT}}
-      escalationPolicy: ${{ESCALATION_POLICY}}
-      servicePrefix: ${{SERVICE_PREFIX}}
-      pagerdutyApiKeySecretRef:
-        name: pagerduty-api-key
-        namespace: ${NAMESPACE}
-      serviceOrchestration:
-        enabled: ${{SERVICE_ORCHESTRATION_ENABLED}}
-        ruleConfigConfigMapRef:
-          name: ${{SERVICE_ORCHESTRATION_RULE_CONFIGMAP}}
-          namespace: ${NAMESPACE}
-      alertGroupingParameters:
-        type: ${{ALERT_GROUPING_TYPE}}
-        config:
-          timeout: ${{ALERT_GROUPING_TIMEOUT}}
-      clusterDeploymentSelector:
-        matchExpressions:
-        - key: api.openshift.com/managed
-          operator: In
-          values: ["true"]
-        - key: api.openshift.com/legal-entity-id
-          operator: NotIn
-          values: ${{SCALE_TEST_LEGALENTITY_IDS}}
-        - key: api.openshift.com/legal-entity-id
-          operator: NotIn
-          values: ${{SILENT_ALERT_LEGALENTITY_IDS}}
-        - key: api.openshift.com/channel-group
-          operator: NotIn
-          values: ["nightly"]
-        - key: api.openshift.com/noalerts
-          operator: NotIn
-          values: ["true"]
-        - key: ext-managed.openshift.io/noalerts
-          operator: NotIn
-          values: ["true"]
-        - key: api.openshift.com/fedramp
-          operator: NotIn
-          values: ["true"]
-      targetSecretRef:
-        name: pd-secret
-        namespace: openshift-monitoring
-  - apiVersion: pagerduty.openshift.io/v1alpha1
-    kind: PagerDutyIntegration
-    metadata:
-      name: osd-silent
-      namespace: ${NAMESPACE}
-    spec:
-      acknowledgeTimeout: ${{ACKNOWLEDGE_TIMEOUT}}
-      resolveTimeout: ${{RESOLVE_TIMEOUT}}
-      escalationPolicy: ${{ESCALATION_POLICY_SILENT}}
-      servicePrefix: ${SERVICE_PREFIX}-silent
-      pagerdutyApiKeySecretRef:
-        name: pagerduty-api-key
-        namespace: ${NAMESPACE}
-      clusterDeploymentSelector:
-        matchExpressions:
-        - key: api.openshift.com/managed
-          operator: In
-          values: ["true"]
-        - key: api.openshift.com/legal-entity-id
-          operator: NotIn
-          values: ${{SCALE_TEST_LEGALENTITY_IDS}}
-        - key: api.openshift.com/legal-entity-id
-          operator: In
-          values: ${{SILENT_ALERT_LEGALENTITY_IDS}}
-        - key: api.openshift.com/noalerts
-          operator: NotIn
-          values: ["true"]
-        - key: ext-managed.openshift.io/noalerts
-          operator: NotIn
-          values: ["true"]
-        - key: api.openshift.com/fedramp
-          operator: NotIn
-          values: ["true"]
-      targetSecretRef:
-        name: pd-secret
-        namespace: openshift-monitoring
-  - apiVersion: pagerduty.openshift.io/v1alpha1
-    kind: PagerDutyIntegration
-    metadata:
-      name: osd-scale-test
-      namespace: ${NAMESPACE}
-    spec:
-      acknowledgeTimeout: ${{ACKNOWLEDGE_TIMEOUT}}
-      resolveTimeout: ${{RESOLVE_TIMEOUT}}
-      escalationPolicy: ${{SCALE_TEST_ESCALATION_POLICY}}
-      servicePrefix: ${{SCALE_TEST_SERVICE_PREFIX}}
-      pagerdutyApiKeySecretRef:
-        name: pagerduty-api-key
-        namespace: ${NAMESPACE}
-      clusterDeploymentSelector:
-        matchExpressions:
-        - key: api.openshift.com/managed
-          operator: In
-          values: ["true"]
-        - key: api.openshift.com/legal-entity-id
-          operator: In
-          values: ${{SCALE_TEST_LEGALENTITY_IDS}}
-        - key: api.openshift.com/channel-group
-          operator: NotIn
-          values: ["nightly"]
-        - key: api.openshift.com/noalerts
-          operator: NotIn
-          values: ["true"]
-        - key: ext-managed.openshift.io/noalerts
-          operator: NotIn
-          values: ["true"]
-        - key: api.openshift.com/fedramp
-          operator: NotIn
-          values: ["true"]
-      targetSecretRef:
-        name: pd-secret
-        namespace: openshift-monitoring
-  - apiVersion: monitoring.coreos.com/v1
-    kind: PrometheusRule
-    metadata:
-      name: pagerduty-integration-api-secret
-      namespace: ${NAMESPACE}
-    spec:
-      groups:
-        - name: pagerduty-integration-api-secret
-          rules:
-            - alert: PagerDutyIntegrationAPISecretError
-              annotations:
-                message: PagerDuty Operator is failing to load PAGERDUTY_API_KEY from Secret specified in PagerDutyIntegration {{ $labels.pagerdutyintegration_name }}. Either the Secret might be missing, or the key might be missing from within the Secret.
-              expr: pagerdutyintegration_secret_loaded < 1
-              for: 15m
-              labels:
-                severity: warning
+        acknowledgeTimeout: ${{ACKNOWLEDGE_TIMEOUT}}
+        resolveTimeout: ${{RESOLVE_TIMEOUT}}
+        escalationPolicy: ${ESCALATION_POLICY}
+        escalationPolicySilent: ${ESCALATION_POLICY_SILENT}
+        servicePrefix: ${SERVICE_PREFIX}
+        silentAlertLegalEntityIds: ${{SILENT_ALERT_LEGALENTITY_IDS}}
+        scaleTestEscalationPolicy: ${SCALE_TEST_ESCALATION_POLICY}
+        scaleTestServicePrefix: ${SCALE_TEST_SERVICE_PREFIX}
+        scaleTestLegalEntityIds: ${{SCALE_TEST_LEGALENTITY_IDS}}
+        serviceOrchestrationEnabled: ${SERVICE_ORCHESTRATION_ENABLED}
+        serviceOrchestrationRuleConfigmap: ${SERVICE_ORCHESTRATION_RULE_CONFIGMAP}
+        alertGroupingType: ${ALERT_GROUPING_TYPE}
+        alertGroupingTimeout: ${{ALERT_GROUPING_TIMEOUT}}
+        serviceOrchestrationRules: ${SERVICE_ORCHESTRATION_RULES}
+        rhInfraServiceOrchestrationRules: ${RH_INFRA_SERVICE_ORCHESTRATION_RULES}


### PR DESCRIPTION
## Summary

- Add complete `deploy_pko/` directory with all PKO manifests for pagerduty-operator migration from OLM to PKO (Package Operator)
- Move PagerDutyIntegration CRs, PrometheusRule, and service orchestration ConfigMap into PKO-managed gotmpls, enabling `managedResourceTypes: [ClusterPackage]` in app-interface
- Add Tekton pipelines, Dockerfile.pko, and ClusterPackage template following the same pattern used by all other migrated operators (AAO, GPO, certman, DMS)

### Details

**Commit 1** (`c957a1a2`): Initial PKO infrastructure generated by `make pko-migrate`, including:
- `deploy_pko/` with CRD, RBAC, ServiceAccount, Deployment gotmpl, Cleanup-OLM-Job
- `build/Dockerfile.pko` and `.tekton/` PKO pipelines
- `hack/pko/clusterpackage.yaml` template

**Commit 2** (`979833bf`): Move operator CRs into PKO-managed gotmpls:
- 3 PagerDutyIntegration gotmpls (osd, osd-silent, osd-scale-test) with per-env config templating
- ConfigMap gotmpl for service orchestration rules (JSON blobs via `{{ .config.field | quote }}`)
- PrometheusRule for PD API secret alert (static YAML)
- Expanded manifest.yaml config schema (~17 fields) with `integrations` phase
- Simplified clusterpackage.yaml to ClusterPackage-only

Follows certman-operator (zero-error deployment) as the gold standard. Compared against all 4 migrated operators for structural correctness.

Ref: https://issues.redhat.com/browse/SREP-3261

## Test plan

- [ ] Tekton PKO pipeline builds successfully (PR check)
- [ ] `kubectl-package validate deploy_pko/` passes (if available)
- [ ] Deploy to integration hive (hivei01ue1) via app-interface MR and verify ClusterPackage Available=True
- [ ] Verify PagerDutyIntegration CRs, ConfigMap, and PrometheusRule are created in `pagerduty-operator` namespace
- [ ] Verify OLM cleanup Job runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)