### PR TITLE
SREP-3261: Add PKO template tests and snapshot fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
     - [Create PagerDutyIntegration](#create-the-pagerdutyintegration-object)
     - [Create ClusterDeployment](#create-the-clusterdeployment-object)
     - [Delete ClusterDeployment](#delete-the-clusterdeployment-object)
+  - [Testing](#testing)
+    - [Unit tests](#unit-tests)
+    - [PKO template tests](#pko-template-tests)
+    - [Regenerating test fixtures](#regenerating-test-fixtures)
 
 ## About
 
@@ -227,3 +231,68 @@ You may need to remove dangling finalizers from the `clusterdeployment` object.
 ```bash
 oc edit clusterdeployment fake-cluster -n fake-cluster-namespace
 ```
+
+## Testing
+
+### Unit tests
+
+Run the full test suite:
+
+```bash
+make test
+```
+
+This runs all Go unit tests including controller tests, utility tests, and PKO
+template tests.
+
+### PKO template tests
+
+The operator is deployed via [Package Operator (PKO)](https://package-operator.run/).
+Deployment manifests live in `deploy_pko/` as Go templates (`.gotmpl` files)
+that PKO renders using config values from the ClusterPackage.
+
+Template tests validate that all `.gotmpl` files render correctly with
+different configurations. There are two layers of testing:
+
+**Go unit tests** (`pkg/pko/template_test.go`):
+
+Structural validation of rendered templates — verifies correct `kind`,
+metadata, phase annotations, config substitution (image, fedramp, escalation
+policies), array rendering via `toJson`, JSON blob quoting, and that
+osd-silent/osd-scale-test PDIs correctly include or omit fields relative to
+the main osd PDI.
+
+```bash
+go test ./pkg/pko/... -v
+```
+
+**PKO snapshot tests** (`deploy_pko/manifest.yaml` `test.template` section):
+
+The `manifest.yaml` defines test contexts with different config values
+(production, integration, empty arrays, fedramp, orchestration-disabled).
+`kubectl-package validate` renders all templates with each context and
+compares the output against snapshot fixtures in `deploy_pko/.test-fixtures/`.
+
+```bash
+kubectl-package validate deploy_pko/
+```
+
+If the output doesn't match the fixtures, validation fails — this catches
+unintended changes to template rendering.
+
+### Regenerating test fixtures
+
+After intentionally modifying a `.gotmpl` file or the `manifest.yaml` config
+schema, the snapshot fixtures need to be regenerated:
+
+```bash
+rm -rf deploy_pko/.test-fixtures
+kubectl-package validate deploy_pko/
+```
+
+This regenerates the fixture directories. Review the changes with `git diff`
+to confirm only the expected fields changed, then commit the updated fixtures
+alongside the template changes.
+
+If `kubectl-package` is not installed, download it from the
+[package-operator releases](https://github.com/package-operator/package-operator/releases).

--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+      - subscriptions
+      - catalogsources
+      - operatorgroups
+    verbs:
+      - list
+      - get
+      - watch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: olm-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: pagerduty-operator
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  ttlSecondsAfterFinished: 100
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: olm-cleanup
+      priorityClassName: openshift-user-critical
+      restartPolicy: Never
+      containers:
+        - name: delete-csv
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              set -euxo pipefail
+              oc -n pagerduty-operator delete csv -l "operators.coreos.com/pagerduty-operator.pagerduty-operator" || true
+              oc -n pagerduty-operator delete subscription.operators.coreos.com pagerduty-operator || true
+              oc -n pagerduty-operator delete catalogsource.operators.coreos.com pagerduty-operator-catalog || true
+              oc -n pagerduty-operator delete operatorgroup.operators.coreos.com pagerduty-operator-og || true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy_pko/.test-fixtures/default/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-pagerduty-operator.yaml
@@ -1,0 +1,79 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - pagerduty.openshift.io
+  resources:
+  - pagerdutyintegrations
+  - pagerdutyintegrations/status
+  - pagerdutyintegrations/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - "get"
+  - "create"
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterdeployments/finalizers
+  - clusterdeployments/status
+  - syncsets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - syncsets
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - '*'

--- a/deploy_pko/.test-fixtures/default/ClusterRoleBinding-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRoleBinding-pagerduty-operator.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+roleRef:
+  kind: ClusterRole
+  name: pagerduty-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/default/ConfigMap-osd-serviceorchestration.yaml
+++ b/deploy_pko/.test-fixtures/default/ConfigMap-osd-serviceorchestration.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osd-serviceorchestration
+  namespace: pagerduty-operator
+  labels:
+    api.openshift.com/managed: "true"
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+data:
+  service-orchestration.json: "{\"orchestration_path\":{\"catch_all\":{\"actions\":{}},\"sets\":[{\"id\":\"start\",\"rules\":[{\"actions\":{\"suppress\":true},\"conditions\":[{\"expression\":\"event.severity matches 'Warning'\"}]}]}],\"type\":\"service\"}}"
+  rh-infra-service-orchestration.json: "{\"orchestration_path\":{\"catch_all\":{\"actions\":{}},\"sets\":[{\"id\":\"start\",\"rules\":[{\"actions\":{\"suppress\":true},\"conditions\":[{\"expression\":\"event.severity matches 'Warning'\"}]},{\"actions\":{\"priority\":\"PDPJP5Q\"},\"conditions\":[]}]}],\"type\":\"service\"}}"

--- a/deploy_pko/.test-fixtures/default/CustomResourceDefinition-pagerdutyintegrations.pagerduty.openshift.io.yaml
+++ b/deploy_pko/.test-fixtures/default/CustomResourceDefinition-pagerdutyintegrations.pagerduty.openshift.io.yaml
@@ -1,0 +1,222 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    package-operator.run/phase: crds
+    package-operator.run/collision-protection: IfNoController
+  name: pagerdutyintegrations.pagerduty.openshift.io
+spec:
+  group: pagerduty.openshift.io
+  names:
+    kind: PagerDutyIntegration
+    listKind: PagerDutyIntegrationList
+    plural: pagerdutyintegrations
+    shortNames:
+    - pdi
+    singular: pagerdutyintegration
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PagerDutyIntegration is the Schema for the pagerdutyintegrations
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PagerDutyIntegrationSpec defines the desired state of PagerDutyIntegration
+            properties:
+              acknowledgeTimeout:
+                description: |-
+                  Time in seconds that an incident changes to the Triggered State after
+                  being Acknowledged. Value must not be negative. Omitting or setting
+                  this field to 0 will disable the feature.
+                minimum: 0
+                type: integer
+              alertGroupingParameters:
+                description: Configures alert grouping for PD services
+                properties:
+                  config:
+                    description: |-
+                      AlertGroupingParametersConfigSpec defines the specifics for how an alert grouping type
+                      should behave
+                    properties:
+                      timeout:
+                        type: integer
+                    type: object
+                  type:
+                    type: string
+                type: object
+              clusterDeploymentSelector:
+                description: |-
+                  A label selector used to find which clusterdeployment CRs receive a
+                  PD integration based on this configuration.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              escalationPolicy:
+                description: ID of an existing Escalation Policy in PagerDuty.
+                type: string
+              pagerdutyApiKeySecretRef:
+                description: Reference to the secret containing PAGERDUTY_API_KEY.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              resolveTimeout:
+                description: |-
+                  Time in seconds that an incident is automatically resolved if left
+                  open for that long. Value must not be negative. Omitting or setting
+                  this field to 0 will disable the feature.
+                minimum: 0
+                type: integer
+              serviceOrchestration:
+                description: ' The status of the serviceOrchestration and the referenced
+                  configmap resource'
+                properties:
+                  enabled:
+                    type: boolean
+                  ruleConfigConfigMapRef:
+                    description: ObjectReference contains enough information to let
+                      you inspect or modify the referred object.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - enabled
+                type: object
+              servicePrefix:
+                description: Prefix to set on the PagerDuty Service name.
+                type: string
+              targetSecretRef:
+                description: Name and namespace in the target cluster where the secret
+                  is synced.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - clusterDeploymentSelector
+            - escalationPolicy
+            - pagerdutyApiKeySecretRef
+            - servicePrefix
+            - targetSecretRef
+            type: object
+          status:
+            description: PagerDutyIntegrationStatus defines the observed state of
+              PagerDutyIntegration
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy_pko/.test-fixtures/default/Deployment-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/Deployment-pagerduty-operator.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pagerduty-operator
+  template:
+    metadata:
+      labels:
+        name: pagerduty-operator
+    spec:
+      serviceAccountName: pagerduty-operator
+      containers:
+      - name: pagerduty-operator
+        image: 'quay.io/example/pagerduty-operator:test'
+        command:
+        - pagerduty-operator
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "2G"
+            cpu: "100m"
+          limits:
+            memory: "2G"
+            cpu: "100m"
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: "pagerduty-operator"
+        - name: FEDRAMP
+          value: 'false'

--- a/deploy_pko/.test-fixtures/default/PagerDutyIntegration-osd-scale-test.yaml
+++ b/deploy_pko/.test-fixtures/default/PagerDutyIntegration-osd-scale-test.yaml
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-scale-test
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PSCALE01
+  servicePrefix: osd-scale-test
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # select specific organizations
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: ["1ep4WsPDKikDQCFLsi2yKdzH8xB"]
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/default/PagerDutyIntegration-osd-silent.yaml
+++ b/deploy_pko/.test-fixtures/default/PagerDutyIntegration-osd-silent.yaml
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-silent
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PSILENT1
+  servicePrefix: osd-silent
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: ["1ep4WsPDKikDQCFLsi2yKdzH8xB"]
+    # for the "silent" PDI, create when CD in specific organizations we ignore in the "osd" (regular) PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: ["1aV37K1VQv2zSStwSkdwBNOUBGI","2Mo8exhgEA5ir1lsVypXUb9v902"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/default/PagerDutyIntegration-osd.yaml
+++ b/deploy_pko/.test-fixtures/default/PagerDutyIntegration-osd.yaml
@@ -1,0 +1,57 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PTEST123
+  servicePrefix: osd
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  serviceOrchestration:
+    enabled: true
+    ruleConfigConfigMapRef:
+      name: osd-serviceorchestration
+      namespace: pagerduty-operator
+  alertGroupingParameters:
+    type: time
+    config:
+      timeout: 300
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: ["1ep4WsPDKikDQCFLsi2yKdzH8xB"]
+    # ignore CD for alerts we wish to route to the silence PD escalation policy
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: ["1aV37K1VQv2zSStwSkdwBNOUBGI","2Mo8exhgEA5ir1lsVypXUb9v902"]
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/default/PrometheusRule-pagerduty-integration-api-secret.yaml
+++ b/deploy_pko/.test-fixtures/default/PrometheusRule-pagerduty-integration-api-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pagerduty-integration-api-secret
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  groups:
+    - name: pagerduty-integration-api-secret
+      rules:
+        - alert: PagerDutyIntegrationAPISecretError
+          annotations:
+            message: PagerDuty Operator is failing to load PAGERDUTY_API_KEY from Secret specified in PagerDutyIntegration {{ $labels.pagerdutyintegration_name }}. Either the Secret might be missing, or the key might be missing from within the Secret.
+          expr: pagerdutyintegration_secret_loaded < 1
+          for: 15m
+          labels:
+            severity: warning

--- a/deploy_pko/.test-fixtures/default/Role-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/default/Role-prometheus-k8s.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/default/RoleBinding-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/default/RoleBinding-prometheus-k8s.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/default/ServiceAccount-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ServiceAccount-pagerduty-operator.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController

--- a/deploy_pko/.test-fixtures/empty-arrays/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/Cleanup-OLM-Job.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+      - subscriptions
+      - catalogsources
+      - operatorgroups
+    verbs:
+      - list
+      - get
+      - watch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: olm-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: pagerduty-operator
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  ttlSecondsAfterFinished: 100
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: olm-cleanup
+      priorityClassName: openshift-user-critical
+      restartPolicy: Never
+      containers:
+        - name: delete-csv
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              set -euxo pipefail
+              oc -n pagerduty-operator delete csv -l "operators.coreos.com/pagerduty-operator.pagerduty-operator" || true
+              oc -n pagerduty-operator delete subscription.operators.coreos.com pagerduty-operator || true
+              oc -n pagerduty-operator delete catalogsource.operators.coreos.com pagerduty-operator-catalog || true
+              oc -n pagerduty-operator delete operatorgroup.operators.coreos.com pagerduty-operator-og || true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy_pko/.test-fixtures/empty-arrays/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/ClusterRole-pagerduty-operator.yaml
@@ -1,0 +1,79 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - pagerduty.openshift.io
+  resources:
+  - pagerdutyintegrations
+  - pagerdutyintegrations/status
+  - pagerdutyintegrations/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - "get"
+  - "create"
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterdeployments/finalizers
+  - clusterdeployments/status
+  - syncsets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - syncsets
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - '*'

--- a/deploy_pko/.test-fixtures/empty-arrays/ClusterRoleBinding-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/ClusterRoleBinding-pagerduty-operator.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+roleRef:
+  kind: ClusterRole
+  name: pagerduty-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/empty-arrays/ConfigMap-osd-serviceorchestration.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/ConfigMap-osd-serviceorchestration.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osd-serviceorchestration
+  namespace: pagerduty-operator
+  labels:
+    api.openshift.com/managed: "true"
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+data:
+  service-orchestration.json: "{}"
+  rh-infra-service-orchestration.json: "{}"

--- a/deploy_pko/.test-fixtures/empty-arrays/CustomResourceDefinition-pagerdutyintegrations.pagerduty.openshift.io.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/CustomResourceDefinition-pagerdutyintegrations.pagerduty.openshift.io.yaml
@@ -1,0 +1,222 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    package-operator.run/phase: crds
+    package-operator.run/collision-protection: IfNoController
+  name: pagerdutyintegrations.pagerduty.openshift.io
+spec:
+  group: pagerduty.openshift.io
+  names:
+    kind: PagerDutyIntegration
+    listKind: PagerDutyIntegrationList
+    plural: pagerdutyintegrations
+    shortNames:
+    - pdi
+    singular: pagerdutyintegration
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PagerDutyIntegration is the Schema for the pagerdutyintegrations
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PagerDutyIntegrationSpec defines the desired state of PagerDutyIntegration
+            properties:
+              acknowledgeTimeout:
+                description: |-
+                  Time in seconds that an incident changes to the Triggered State after
+                  being Acknowledged. Value must not be negative. Omitting or setting
+                  this field to 0 will disable the feature.
+                minimum: 0
+                type: integer
+              alertGroupingParameters:
+                description: Configures alert grouping for PD services
+                properties:
+                  config:
+                    description: |-
+                      AlertGroupingParametersConfigSpec defines the specifics for how an alert grouping type
+                      should behave
+                    properties:
+                      timeout:
+                        type: integer
+                    type: object
+                  type:
+                    type: string
+                type: object
+              clusterDeploymentSelector:
+                description: |-
+                  A label selector used to find which clusterdeployment CRs receive a
+                  PD integration based on this configuration.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              escalationPolicy:
+                description: ID of an existing Escalation Policy in PagerDuty.
+                type: string
+              pagerdutyApiKeySecretRef:
+                description: Reference to the secret containing PAGERDUTY_API_KEY.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              resolveTimeout:
+                description: |-
+                  Time in seconds that an incident is automatically resolved if left
+                  open for that long. Value must not be negative. Omitting or setting
+                  this field to 0 will disable the feature.
+                minimum: 0
+                type: integer
+              serviceOrchestration:
+                description: ' The status of the serviceOrchestration and the referenced
+                  configmap resource'
+                properties:
+                  enabled:
+                    type: boolean
+                  ruleConfigConfigMapRef:
+                    description: ObjectReference contains enough information to let
+                      you inspect or modify the referred object.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - enabled
+                type: object
+              servicePrefix:
+                description: Prefix to set on the PagerDuty Service name.
+                type: string
+              targetSecretRef:
+                description: Name and namespace in the target cluster where the secret
+                  is synced.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - clusterDeploymentSelector
+            - escalationPolicy
+            - pagerdutyApiKeySecretRef
+            - servicePrefix
+            - targetSecretRef
+            type: object
+          status:
+            description: PagerDutyIntegrationStatus defines the observed state of
+              PagerDutyIntegration
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy_pko/.test-fixtures/empty-arrays/Deployment-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/Deployment-pagerduty-operator.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pagerduty-operator
+  template:
+    metadata:
+      labels:
+        name: pagerduty-operator
+    spec:
+      serviceAccountName: pagerduty-operator
+      containers:
+      - name: pagerduty-operator
+        image: 'quay.io/example/pagerduty-operator:test'
+        command:
+        - pagerduty-operator
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "2G"
+            cpu: "100m"
+          limits:
+            memory: "2G"
+            cpu: "100m"
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: "pagerduty-operator"
+        - name: FEDRAMP
+          value: 'false'

--- a/deploy_pko/.test-fixtures/empty-arrays/PagerDutyIntegration-osd-scale-test.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/PagerDutyIntegration-osd-scale-test.yaml
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-scale-test
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PSCALE01
+  servicePrefix: osd-scale-test
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # select specific organizations
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: []
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/empty-arrays/PagerDutyIntegration-osd-silent.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/PagerDutyIntegration-osd-silent.yaml
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-silent
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PSILENT1
+  servicePrefix: osd-silent
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: []
+    # for the "silent" PDI, create when CD in specific organizations we ignore in the "osd" (regular) PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: []
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/empty-arrays/PagerDutyIntegration-osd.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/PagerDutyIntegration-osd.yaml
@@ -1,0 +1,57 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PTEST123
+  servicePrefix: osd
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  serviceOrchestration:
+    enabled: true
+    ruleConfigConfigMapRef:
+      name: osd-serviceorchestration
+      namespace: pagerduty-operator
+  alertGroupingParameters:
+    type: 
+    config:
+      timeout: 0
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: []
+    # ignore CD for alerts we wish to route to the silence PD escalation policy
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: []
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/empty-arrays/PrometheusRule-pagerduty-integration-api-secret.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/PrometheusRule-pagerduty-integration-api-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pagerduty-integration-api-secret
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  groups:
+    - name: pagerduty-integration-api-secret
+      rules:
+        - alert: PagerDutyIntegrationAPISecretError
+          annotations:
+            message: PagerDuty Operator is failing to load PAGERDUTY_API_KEY from Secret specified in PagerDutyIntegration {{ $labels.pagerdutyintegration_name }}. Either the Secret might be missing, or the key might be missing from within the Secret.
+          expr: pagerdutyintegration_secret_loaded < 1
+          for: 15m
+          labels:
+            severity: warning

--- a/deploy_pko/.test-fixtures/empty-arrays/Role-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/Role-prometheus-k8s.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/empty-arrays/RoleBinding-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/RoleBinding-prometheus-k8s.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/empty-arrays/ServiceAccount-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/ServiceAccount-pagerduty-operator.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+      - subscriptions
+      - catalogsources
+      - operatorgroups
+    verbs:
+      - list
+      - get
+      - watch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: olm-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: pagerduty-operator
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  ttlSecondsAfterFinished: 100
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: olm-cleanup
+      priorityClassName: openshift-user-critical
+      restartPolicy: Never
+      containers:
+        - name: delete-csv
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              set -euxo pipefail
+              oc -n pagerduty-operator delete csv -l "operators.coreos.com/pagerduty-operator.pagerduty-operator" || true
+              oc -n pagerduty-operator delete subscription.operators.coreos.com pagerduty-operator || true
+              oc -n pagerduty-operator delete catalogsource.operators.coreos.com pagerduty-operator-catalog || true
+              oc -n pagerduty-operator delete operatorgroup.operators.coreos.com pagerduty-operator-og || true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRole-pagerduty-operator.yaml
@@ -1,0 +1,79 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - pagerduty.openshift.io
+  resources:
+  - pagerdutyintegrations
+  - pagerdutyintegrations/status
+  - pagerdutyintegrations/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - "get"
+  - "create"
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterdeployments/finalizers
+  - clusterdeployments/status
+  - syncsets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - syncsets
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - '*'

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-pagerduty-operator.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+roleRef:
+  kind: ClusterRole
+  name: pagerduty-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/fedramp/ConfigMap-osd-serviceorchestration.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ConfigMap-osd-serviceorchestration.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osd-serviceorchestration
+  namespace: pagerduty-operator
+  labels:
+    api.openshift.com/managed: "true"
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+data:
+  service-orchestration.json: "{}"
+  rh-infra-service-orchestration.json: "{}"

--- a/deploy_pko/.test-fixtures/fedramp/CustomResourceDefinition-pagerdutyintegrations.pagerduty.openshift.io.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/CustomResourceDefinition-pagerdutyintegrations.pagerduty.openshift.io.yaml
@@ -1,0 +1,222 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    package-operator.run/phase: crds
+    package-operator.run/collision-protection: IfNoController
+  name: pagerdutyintegrations.pagerduty.openshift.io
+spec:
+  group: pagerduty.openshift.io
+  names:
+    kind: PagerDutyIntegration
+    listKind: PagerDutyIntegrationList
+    plural: pagerdutyintegrations
+    shortNames:
+    - pdi
+    singular: pagerdutyintegration
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PagerDutyIntegration is the Schema for the pagerdutyintegrations
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PagerDutyIntegrationSpec defines the desired state of PagerDutyIntegration
+            properties:
+              acknowledgeTimeout:
+                description: |-
+                  Time in seconds that an incident changes to the Triggered State after
+                  being Acknowledged. Value must not be negative. Omitting or setting
+                  this field to 0 will disable the feature.
+                minimum: 0
+                type: integer
+              alertGroupingParameters:
+                description: Configures alert grouping for PD services
+                properties:
+                  config:
+                    description: |-
+                      AlertGroupingParametersConfigSpec defines the specifics for how an alert grouping type
+                      should behave
+                    properties:
+                      timeout:
+                        type: integer
+                    type: object
+                  type:
+                    type: string
+                type: object
+              clusterDeploymentSelector:
+                description: |-
+                  A label selector used to find which clusterdeployment CRs receive a
+                  PD integration based on this configuration.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              escalationPolicy:
+                description: ID of an existing Escalation Policy in PagerDuty.
+                type: string
+              pagerdutyApiKeySecretRef:
+                description: Reference to the secret containing PAGERDUTY_API_KEY.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              resolveTimeout:
+                description: |-
+                  Time in seconds that an incident is automatically resolved if left
+                  open for that long. Value must not be negative. Omitting or setting
+                  this field to 0 will disable the feature.
+                minimum: 0
+                type: integer
+              serviceOrchestration:
+                description: ' The status of the serviceOrchestration and the referenced
+                  configmap resource'
+                properties:
+                  enabled:
+                    type: boolean
+                  ruleConfigConfigMapRef:
+                    description: ObjectReference contains enough information to let
+                      you inspect or modify the referred object.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - enabled
+                type: object
+              servicePrefix:
+                description: Prefix to set on the PagerDuty Service name.
+                type: string
+              targetSecretRef:
+                description: Name and namespace in the target cluster where the secret
+                  is synced.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - clusterDeploymentSelector
+            - escalationPolicy
+            - pagerdutyApiKeySecretRef
+            - servicePrefix
+            - targetSecretRef
+            type: object
+          status:
+            description: PagerDutyIntegrationStatus defines the observed state of
+              PagerDutyIntegration
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy_pko/.test-fixtures/fedramp/Deployment-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Deployment-pagerduty-operator.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pagerduty-operator
+  template:
+    metadata:
+      labels:
+        name: pagerduty-operator
+    spec:
+      serviceAccountName: pagerduty-operator
+      containers:
+      - name: pagerduty-operator
+        image: 'quay.io/example/pagerduty-operator:test'
+        command:
+        - pagerduty-operator
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "2G"
+            cpu: "100m"
+          limits:
+            memory: "2G"
+            cpu: "100m"
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: "pagerduty-operator"
+        - name: FEDRAMP
+          value: 'true'

--- a/deploy_pko/.test-fixtures/fedramp/PagerDutyIntegration-osd-scale-test.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/PagerDutyIntegration-osd-scale-test.yaml
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-scale-test
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PSCALE01
+  servicePrefix: osd-scale-test
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # select specific organizations
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: []
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/fedramp/PagerDutyIntegration-osd-silent.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/PagerDutyIntegration-osd-silent.yaml
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-silent
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PSILENT1
+  servicePrefix: osd-silent
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: []
+    # for the "silent" PDI, create when CD in specific organizations we ignore in the "osd" (regular) PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: []
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/fedramp/PagerDutyIntegration-osd.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/PagerDutyIntegration-osd.yaml
@@ -1,0 +1,57 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PTEST123
+  servicePrefix: osd
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  serviceOrchestration:
+    enabled: false
+    ruleConfigConfigMapRef:
+      name: osd-serviceorchestration
+      namespace: pagerduty-operator
+  alertGroupingParameters:
+    type: 
+    config:
+      timeout: 0
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: []
+    # ignore CD for alerts we wish to route to the silence PD escalation policy
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: []
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/fedramp/PrometheusRule-pagerduty-integration-api-secret.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/PrometheusRule-pagerduty-integration-api-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pagerduty-integration-api-secret
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  groups:
+    - name: pagerduty-integration-api-secret
+      rules:
+        - alert: PagerDutyIntegrationAPISecretError
+          annotations:
+            message: PagerDuty Operator is failing to load PAGERDUTY_API_KEY from Secret specified in PagerDutyIntegration {{ $labels.pagerdutyintegration_name }}. Either the Secret might be missing, or the key might be missing from within the Secret.
+          expr: pagerdutyintegration_secret_loaded < 1
+          for: 15m
+          labels:
+            severity: warning

--- a/deploy_pko/.test-fixtures/fedramp/Role-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Role-prometheus-k8s.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/fedramp/RoleBinding-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/RoleBinding-prometheus-k8s.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/fedramp/ServiceAccount-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ServiceAccount-pagerduty-operator.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController

--- a/deploy_pko/.test-fixtures/integration/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/integration/Cleanup-OLM-Job.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+      - subscriptions
+      - catalogsources
+      - operatorgroups
+    verbs:
+      - list
+      - get
+      - watch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: olm-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: pagerduty-operator
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  ttlSecondsAfterFinished: 100
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: olm-cleanup
+      priorityClassName: openshift-user-critical
+      restartPolicy: Never
+      containers:
+        - name: delete-csv
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              set -euxo pipefail
+              oc -n pagerduty-operator delete csv -l "operators.coreos.com/pagerduty-operator.pagerduty-operator" || true
+              oc -n pagerduty-operator delete subscription.operators.coreos.com pagerduty-operator || true
+              oc -n pagerduty-operator delete catalogsource.operators.coreos.com pagerduty-operator-catalog || true
+              oc -n pagerduty-operator delete operatorgroup.operators.coreos.com pagerduty-operator-og || true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy_pko/.test-fixtures/integration/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/integration/ClusterRole-pagerduty-operator.yaml
@@ -1,0 +1,79 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - pagerduty.openshift.io
+  resources:
+  - pagerdutyintegrations
+  - pagerdutyintegrations/status
+  - pagerdutyintegrations/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - "get"
+  - "create"
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterdeployments/finalizers
+  - clusterdeployments/status
+  - syncsets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - syncsets
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - '*'

--- a/deploy_pko/.test-fixtures/integration/ClusterRoleBinding-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/integration/ClusterRoleBinding-pagerduty-operator.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+roleRef:
+  kind: ClusterRole
+  name: pagerduty-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/integration/ConfigMap-osd-serviceorchestration.yaml
+++ b/deploy_pko/.test-fixtures/integration/ConfigMap-osd-serviceorchestration.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osd-serviceorchestration
+  namespace: pagerduty-operator
+  labels:
+    api.openshift.com/managed: "true"
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+data:
+  service-orchestration.json: "{\"orchestration_path\":{\"catch_all\":{\"actions\":{}},\"sets\":[{\"id\":\"start\",\"rules\":[{\"actions\":{\"suppress\":true},\"conditions\":[{\"expression\":\"event.severity matches 'Warning'\"}]}]}],\"type\":\"service\"}}"
+  rh-infra-service-orchestration.json: "{\"orchestration_path\":{\"catch_all\":{\"actions\":{}},\"sets\":[{\"id\":\"start\",\"rules\":[{\"actions\":{\"suppress\":true},\"conditions\":[{\"expression\":\"event.severity matches 'Warning'\"}]},{\"actions\":{\"priority\":\"PDPJP5Q\"},\"conditions\":[]}]}],\"type\":\"service\"}}"

--- a/deploy_pko/.test-fixtures/integration/CustomResourceDefinition-pagerdutyintegrations.pagerduty.openshift.io.yaml
+++ b/deploy_pko/.test-fixtures/integration/CustomResourceDefinition-pagerdutyintegrations.pagerduty.openshift.io.yaml
@@ -1,0 +1,222 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    package-operator.run/phase: crds
+    package-operator.run/collision-protection: IfNoController
+  name: pagerdutyintegrations.pagerduty.openshift.io
+spec:
+  group: pagerduty.openshift.io
+  names:
+    kind: PagerDutyIntegration
+    listKind: PagerDutyIntegrationList
+    plural: pagerdutyintegrations
+    shortNames:
+    - pdi
+    singular: pagerdutyintegration
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PagerDutyIntegration is the Schema for the pagerdutyintegrations
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PagerDutyIntegrationSpec defines the desired state of PagerDutyIntegration
+            properties:
+              acknowledgeTimeout:
+                description: |-
+                  Time in seconds that an incident changes to the Triggered State after
+                  being Acknowledged. Value must not be negative. Omitting or setting
+                  this field to 0 will disable the feature.
+                minimum: 0
+                type: integer
+              alertGroupingParameters:
+                description: Configures alert grouping for PD services
+                properties:
+                  config:
+                    description: |-
+                      AlertGroupingParametersConfigSpec defines the specifics for how an alert grouping type
+                      should behave
+                    properties:
+                      timeout:
+                        type: integer
+                    type: object
+                  type:
+                    type: string
+                type: object
+              clusterDeploymentSelector:
+                description: |-
+                  A label selector used to find which clusterdeployment CRs receive a
+                  PD integration based on this configuration.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              escalationPolicy:
+                description: ID of an existing Escalation Policy in PagerDuty.
+                type: string
+              pagerdutyApiKeySecretRef:
+                description: Reference to the secret containing PAGERDUTY_API_KEY.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              resolveTimeout:
+                description: |-
+                  Time in seconds that an incident is automatically resolved if left
+                  open for that long. Value must not be negative. Omitting or setting
+                  this field to 0 will disable the feature.
+                minimum: 0
+                type: integer
+              serviceOrchestration:
+                description: ' The status of the serviceOrchestration and the referenced
+                  configmap resource'
+                properties:
+                  enabled:
+                    type: boolean
+                  ruleConfigConfigMapRef:
+                    description: ObjectReference contains enough information to let
+                      you inspect or modify the referred object.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - enabled
+                type: object
+              servicePrefix:
+                description: Prefix to set on the PagerDuty Service name.
+                type: string
+              targetSecretRef:
+                description: Name and namespace in the target cluster where the secret
+                  is synced.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - clusterDeploymentSelector
+            - escalationPolicy
+            - pagerdutyApiKeySecretRef
+            - servicePrefix
+            - targetSecretRef
+            type: object
+          status:
+            description: PagerDutyIntegrationStatus defines the observed state of
+              PagerDutyIntegration
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy_pko/.test-fixtures/integration/Deployment-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/integration/Deployment-pagerduty-operator.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pagerduty-operator
+  template:
+    metadata:
+      labels:
+        name: pagerduty-operator
+    spec:
+      serviceAccountName: pagerduty-operator
+      containers:
+      - name: pagerduty-operator
+        image: 'quay.io/example/pagerduty-operator:test'
+        command:
+        - pagerduty-operator
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "2G"
+            cpu: "100m"
+          limits:
+            memory: "2G"
+            cpu: "100m"
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: "pagerduty-operator"
+        - name: FEDRAMP
+          value: 'false'

--- a/deploy_pko/.test-fixtures/integration/PagerDutyIntegration-osd-scale-test.yaml
+++ b/deploy_pko/.test-fixtures/integration/PagerDutyIntegration-osd-scale-test.yaml
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-scale-test
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PKCHC7O
+  servicePrefix: osd-scale-test
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # select specific organizations
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: ["1ep4WsPDKikDQCFLsi2yKdzH8xB"]
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/integration/PagerDutyIntegration-osd-silent.yaml
+++ b/deploy_pko/.test-fixtures/integration/PagerDutyIntegration-osd-silent.yaml
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-silent
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PNCPMTV
+  servicePrefix: osdint-silent
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: ["1ep4WsPDKikDQCFLsi2yKdzH8xB"]
+    # for the "silent" PDI, create when CD in specific organizations we ignore in the "osd" (regular) PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: []
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/integration/PagerDutyIntegration-osd.yaml
+++ b/deploy_pko/.test-fixtures/integration/PagerDutyIntegration-osd.yaml
@@ -1,0 +1,57 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PA2GM5L
+  servicePrefix: osdint
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  serviceOrchestration:
+    enabled: true
+    ruleConfigConfigMapRef:
+      name: osd-serviceorchestration
+      namespace: pagerduty-operator
+  alertGroupingParameters:
+    type: 
+    config:
+      timeout: 0
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: ["1ep4WsPDKikDQCFLsi2yKdzH8xB"]
+    # ignore CD for alerts we wish to route to the silence PD escalation policy
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: []
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/integration/PrometheusRule-pagerduty-integration-api-secret.yaml
+++ b/deploy_pko/.test-fixtures/integration/PrometheusRule-pagerduty-integration-api-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pagerduty-integration-api-secret
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  groups:
+    - name: pagerduty-integration-api-secret
+      rules:
+        - alert: PagerDutyIntegrationAPISecretError
+          annotations:
+            message: PagerDuty Operator is failing to load PAGERDUTY_API_KEY from Secret specified in PagerDutyIntegration {{ $labels.pagerdutyintegration_name }}. Either the Secret might be missing, or the key might be missing from within the Secret.
+          expr: pagerdutyintegration_secret_loaded < 1
+          for: 15m
+          labels:
+            severity: warning

--- a/deploy_pko/.test-fixtures/integration/Role-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/integration/Role-prometheus-k8s.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/integration/RoleBinding-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/integration/RoleBinding-prometheus-k8s.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/integration/ServiceAccount-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/integration/ServiceAccount-pagerduty-operator.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController

--- a/deploy_pko/.test-fixtures/orchestration-disabled/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/Cleanup-OLM-Job.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+      - subscriptions
+      - catalogsources
+      - operatorgroups
+    verbs:
+      - list
+      - get
+      - watch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: olm-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: pagerduty-operator
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: olm-cleanup
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: cleanup-deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  ttlSecondsAfterFinished: 100
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: olm-cleanup
+      priorityClassName: openshift-user-critical
+      restartPolicy: Never
+      containers:
+        - name: delete-csv
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              set -euxo pipefail
+              oc -n pagerduty-operator delete csv -l "operators.coreos.com/pagerduty-operator.pagerduty-operator" || true
+              oc -n pagerduty-operator delete subscription.operators.coreos.com pagerduty-operator || true
+              oc -n pagerduty-operator delete catalogsource.operators.coreos.com pagerduty-operator-catalog || true
+              oc -n pagerduty-operator delete operatorgroup.operators.coreos.com pagerduty-operator-og || true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy_pko/.test-fixtures/orchestration-disabled/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/ClusterRole-pagerduty-operator.yaml
@@ -1,0 +1,79 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - pagerduty.openshift.io
+  resources:
+  - pagerdutyintegrations
+  - pagerdutyintegrations/status
+  - pagerdutyintegrations/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - "get"
+  - "create"
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterdeployments/finalizers
+  - clusterdeployments/status
+  - syncsets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - syncsets
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - '*'

--- a/deploy_pko/.test-fixtures/orchestration-disabled/ClusterRoleBinding-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/ClusterRoleBinding-pagerduty-operator.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+roleRef:
+  kind: ClusterRole
+  name: pagerduty-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/orchestration-disabled/ConfigMap-osd-serviceorchestration.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/ConfigMap-osd-serviceorchestration.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osd-serviceorchestration
+  namespace: pagerduty-operator
+  labels:
+    api.openshift.com/managed: "true"
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+data:
+  service-orchestration.json: "{}"
+  rh-infra-service-orchestration.json: "{}"

--- a/deploy_pko/.test-fixtures/orchestration-disabled/CustomResourceDefinition-pagerdutyintegrations.pagerduty.openshift.io.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/CustomResourceDefinition-pagerdutyintegrations.pagerduty.openshift.io.yaml
@@ -1,0 +1,222 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    package-operator.run/phase: crds
+    package-operator.run/collision-protection: IfNoController
+  name: pagerdutyintegrations.pagerduty.openshift.io
+spec:
+  group: pagerduty.openshift.io
+  names:
+    kind: PagerDutyIntegration
+    listKind: PagerDutyIntegrationList
+    plural: pagerdutyintegrations
+    shortNames:
+    - pdi
+    singular: pagerdutyintegration
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PagerDutyIntegration is the Schema for the pagerdutyintegrations
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PagerDutyIntegrationSpec defines the desired state of PagerDutyIntegration
+            properties:
+              acknowledgeTimeout:
+                description: |-
+                  Time in seconds that an incident changes to the Triggered State after
+                  being Acknowledged. Value must not be negative. Omitting or setting
+                  this field to 0 will disable the feature.
+                minimum: 0
+                type: integer
+              alertGroupingParameters:
+                description: Configures alert grouping for PD services
+                properties:
+                  config:
+                    description: |-
+                      AlertGroupingParametersConfigSpec defines the specifics for how an alert grouping type
+                      should behave
+                    properties:
+                      timeout:
+                        type: integer
+                    type: object
+                  type:
+                    type: string
+                type: object
+              clusterDeploymentSelector:
+                description: |-
+                  A label selector used to find which clusterdeployment CRs receive a
+                  PD integration based on this configuration.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              escalationPolicy:
+                description: ID of an existing Escalation Policy in PagerDuty.
+                type: string
+              pagerdutyApiKeySecretRef:
+                description: Reference to the secret containing PAGERDUTY_API_KEY.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              resolveTimeout:
+                description: |-
+                  Time in seconds that an incident is automatically resolved if left
+                  open for that long. Value must not be negative. Omitting or setting
+                  this field to 0 will disable the feature.
+                minimum: 0
+                type: integer
+              serviceOrchestration:
+                description: ' The status of the serviceOrchestration and the referenced
+                  configmap resource'
+                properties:
+                  enabled:
+                    type: boolean
+                  ruleConfigConfigMapRef:
+                    description: ObjectReference contains enough information to let
+                      you inspect or modify the referred object.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - enabled
+                type: object
+              servicePrefix:
+                description: Prefix to set on the PagerDuty Service name.
+                type: string
+              targetSecretRef:
+                description: Name and namespace in the target cluster where the secret
+                  is synced.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - clusterDeploymentSelector
+            - escalationPolicy
+            - pagerdutyApiKeySecretRef
+            - servicePrefix
+            - targetSecretRef
+            type: object
+          status:
+            description: PagerDutyIntegrationStatus defines the observed state of
+              PagerDutyIntegration
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy_pko/.test-fixtures/orchestration-disabled/Deployment-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/Deployment-pagerduty-operator.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pagerduty-operator
+  template:
+    metadata:
+      labels:
+        name: pagerduty-operator
+    spec:
+      serviceAccountName: pagerduty-operator
+      containers:
+      - name: pagerduty-operator
+        image: 'quay.io/example/pagerduty-operator:test'
+        command:
+        - pagerduty-operator
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "2G"
+            cpu: "100m"
+          limits:
+            memory: "2G"
+            cpu: "100m"
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: "pagerduty-operator"
+        - name: FEDRAMP
+          value: 'false'

--- a/deploy_pko/.test-fixtures/orchestration-disabled/PagerDutyIntegration-osd-scale-test.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/PagerDutyIntegration-osd-scale-test.yaml
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-scale-test
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PSCALE01
+  servicePrefix: osd-scale-test
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # select specific organizations
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: ["1ep4WsPDKikDQCFLsi2yKdzH8xB"]
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/orchestration-disabled/PagerDutyIntegration-osd-silent.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/PagerDutyIntegration-osd-silent.yaml
@@ -1,0 +1,44 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd-silent
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PSILENT1
+  servicePrefix: osd-silent
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: ["1ep4WsPDKikDQCFLsi2yKdzH8xB"]
+    # for the "silent" PDI, create when CD in specific organizations we ignore in the "osd" (regular) PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: ["1aV37K1VQv2zSStwSkdwBNOUBGI"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/orchestration-disabled/PagerDutyIntegration-osd.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/PagerDutyIntegration-osd.yaml
@@ -1,0 +1,57 @@
+apiVersion: pagerduty.openshift.io/v1alpha1
+kind: PagerDutyIntegration
+metadata:
+  name: osd
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  acknowledgeTimeout: 21600
+  resolveTimeout: 0
+  escalationPolicy: PTEST123
+  servicePrefix: osd
+  pagerdutyApiKeySecretRef:
+    name: pagerduty-api-key
+    namespace: pagerduty-operator
+  serviceOrchestration:
+    enabled: false
+    ruleConfigConfigMapRef:
+      name: osd-serviceorchestration
+      namespace: pagerduty-operator
+  alertGroupingParameters:
+    type: 
+    config:
+      timeout: 0
+  clusterDeploymentSelector:
+    matchExpressions:
+    # only create PD service for managed (OSD) clusters
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    # ignore CD if its a scale test organization, scale test org has its own PDI
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: ["1ep4WsPDKikDQCFLsi2yKdzH8xB"]
+    # ignore CD for alerts we wish to route to the silence PD escalation policy
+    - key: api.openshift.com/legal-entity-id
+      operator: NotIn
+      values: ["1aV37K1VQv2zSStwSkdwBNOUBGI"]
+    # ignore CD for any "nightly" clusters
+    - key: api.openshift.com/channel-group
+      operator: NotIn
+      values: ["nightly"]
+    # ignore CD w/ "legacy" noalerts label
+    - key: api.openshift.com/noalerts
+      operator: NotIn
+      values: ["true"]
+    # ignore CD w/ ext noalerts label
+    - key: ext-managed.openshift.io/noalerts
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+  targetSecretRef:
+    name: pd-secret
+    namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/orchestration-disabled/PrometheusRule-pagerduty-integration-api-secret.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/PrometheusRule-pagerduty-integration-api-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pagerduty-integration-api-secret
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: integrations
+    package-operator.run/collision-protection: IfNoController
+spec:
+  groups:
+    - name: pagerduty-integration-api-secret
+      rules:
+        - alert: PagerDutyIntegrationAPISecretError
+          annotations:
+            message: PagerDuty Operator is failing to load PAGERDUTY_API_KEY from Secret specified in PagerDutyIntegration {{ $labels.pagerdutyintegration_name }}. Either the Secret might be missing, or the key might be missing from within the Secret.
+          expr: pagerdutyintegration_secret_loaded < 1
+          for: 15m
+          labels:
+            severity: warning

--- a/deploy_pko/.test-fixtures/orchestration-disabled/Role-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/Role-prometheus-k8s.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/orchestration-disabled/RoleBinding-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/RoleBinding-prometheus-k8s.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/orchestration-disabled/ServiceAccount-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/ServiceAccount-pagerduty-operator.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pagerduty-operator
+  namespace: pagerduty-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -96,3 +96,131 @@ spec:
           description: JSON rules for RH infra PagerDuty service orchestration
           type: string
           default: "{}"
+test:
+  template:
+  - name: default
+    context:
+      package:
+        metadata:
+          name: pagerduty-operator
+          namespace: pagerduty-operator
+      config:
+        image: quay.io/example/pagerduty-operator:test
+        fedramp: "false"
+        acknowledgeTimeout: 21600
+        resolveTimeout: 0
+        escalationPolicy: PTEST123
+        escalationPolicySilent: PSILENT1
+        servicePrefix: osd
+        silentAlertLegalEntityIds:
+        - "1aV37K1VQv2zSStwSkdwBNOUBGI"
+        - "2Mo8exhgEA5ir1lsVypXUb9v902"
+        scaleTestEscalationPolicy: PSCALE01
+        scaleTestServicePrefix: osd-scale-test
+        scaleTestLegalEntityIds:
+        - "1ep4WsPDKikDQCFLsi2yKdzH8xB"
+        serviceOrchestrationEnabled: "true"
+        serviceOrchestrationRuleConfigmap: osd-serviceorchestration
+        alertGroupingType: time
+        alertGroupingTimeout: 300
+        serviceOrchestrationRules: '{"orchestration_path":{"catch_all":{"actions":{}},"sets":[{"id":"start","rules":[{"actions":{"suppress":true},"conditions":[{"expression":"event.severity matches ''Warning''"}]}]}],"type":"service"}}'
+        rhInfraServiceOrchestrationRules: '{"orchestration_path":{"catch_all":{"actions":{}},"sets":[{"id":"start","rules":[{"actions":{"suppress":true},"conditions":[{"expression":"event.severity matches ''Warning''"}]},{"actions":{"priority":"PDPJP5Q"},"conditions":[]}]}],"type":"service"}}'
+  - name: integration
+    context:
+      package:
+        metadata:
+          name: pagerduty-operator
+          namespace: pagerduty-operator
+      config:
+        image: quay.io/example/pagerduty-operator:test
+        fedramp: "false"
+        acknowledgeTimeout: 21600
+        resolveTimeout: 0
+        escalationPolicy: PA2GM5L
+        escalationPolicySilent: PNCPMTV
+        servicePrefix: osdint
+        silentAlertLegalEntityIds: []
+        scaleTestEscalationPolicy: PKCHC7O
+        scaleTestServicePrefix: osd-scale-test
+        scaleTestLegalEntityIds:
+        - "1ep4WsPDKikDQCFLsi2yKdzH8xB"
+        serviceOrchestrationEnabled: "true"
+        serviceOrchestrationRuleConfigmap: osd-serviceorchestration
+        alertGroupingType: ""
+        alertGroupingTimeout: 0
+        serviceOrchestrationRules: '{"orchestration_path":{"catch_all":{"actions":{}},"sets":[{"id":"start","rules":[{"actions":{"suppress":true},"conditions":[{"expression":"event.severity matches ''Warning''"}]}]}],"type":"service"}}'
+        rhInfraServiceOrchestrationRules: '{"orchestration_path":{"catch_all":{"actions":{}},"sets":[{"id":"start","rules":[{"actions":{"suppress":true},"conditions":[{"expression":"event.severity matches ''Warning''"}]},{"actions":{"priority":"PDPJP5Q"},"conditions":[]}]}],"type":"service"}}'
+  - name: empty-arrays
+    context:
+      package:
+        metadata:
+          name: pagerduty-operator
+          namespace: pagerduty-operator
+      config:
+        image: quay.io/example/pagerduty-operator:test
+        fedramp: "false"
+        acknowledgeTimeout: 21600
+        resolveTimeout: 0
+        escalationPolicy: PTEST123
+        escalationPolicySilent: PSILENT1
+        servicePrefix: osd
+        silentAlertLegalEntityIds: []
+        scaleTestEscalationPolicy: PSCALE01
+        scaleTestServicePrefix: osd-scale-test
+        scaleTestLegalEntityIds: []
+        serviceOrchestrationEnabled: "true"
+        serviceOrchestrationRuleConfigmap: osd-serviceorchestration
+        alertGroupingType: ""
+        alertGroupingTimeout: 0
+        serviceOrchestrationRules: "{}"
+        rhInfraServiceOrchestrationRules: "{}"
+  - name: fedramp
+    context:
+      package:
+        metadata:
+          name: pagerduty-operator
+          namespace: pagerduty-operator
+      config:
+        image: quay.io/example/pagerduty-operator:test
+        fedramp: "true"
+        acknowledgeTimeout: 21600
+        resolveTimeout: 0
+        escalationPolicy: PTEST123
+        escalationPolicySilent: PSILENT1
+        servicePrefix: osd
+        silentAlertLegalEntityIds: []
+        scaleTestEscalationPolicy: PSCALE01
+        scaleTestServicePrefix: osd-scale-test
+        scaleTestLegalEntityIds: []
+        serviceOrchestrationEnabled: "false"
+        serviceOrchestrationRuleConfigmap: osd-serviceorchestration
+        alertGroupingType: ""
+        alertGroupingTimeout: 0
+        serviceOrchestrationRules: "{}"
+        rhInfraServiceOrchestrationRules: "{}"
+  - name: orchestration-disabled
+    context:
+      package:
+        metadata:
+          name: pagerduty-operator
+          namespace: pagerduty-operator
+      config:
+        image: quay.io/example/pagerduty-operator:test
+        fedramp: "false"
+        acknowledgeTimeout: 21600
+        resolveTimeout: 0
+        escalationPolicy: PTEST123
+        escalationPolicySilent: PSILENT1
+        servicePrefix: osd
+        silentAlertLegalEntityIds:
+        - "1aV37K1VQv2zSStwSkdwBNOUBGI"
+        scaleTestEscalationPolicy: PSCALE01
+        scaleTestServicePrefix: osd-scale-test
+        scaleTestLegalEntityIds:
+        - "1ep4WsPDKikDQCFLsi2yKdzH8xB"
+        serviceOrchestrationEnabled: "false"
+        serviceOrchestrationRuleConfigmap: osd-serviceorchestration
+        alertGroupingType: ""
+        alertGroupingTimeout: 0
+        serviceOrchestrationRules: "{}"
+        rhInfraServiceOrchestrationRules: "{}"

--- a/pkg/pko/template_test.go
+++ b/pkg/pko/template_test.go
@@ -1,0 +1,384 @@
+package pko
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+// deployPkoDir returns the path to the deploy_pko directory relative to the repo root.
+func deployPkoDir() string {
+	dir, _ := os.Getwd()
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "deploy_pko")); err == nil {
+			return filepath.Join(dir, "deploy_pko")
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "deploy_pko"
+}
+
+// templateFuncMap provides the functions available in PKO gotmpls.
+func templateFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"toJson": func(v interface{}) string {
+			b, _ := json.Marshal(v)
+			return string(b)
+		},
+		"quote": func(v interface{}) string {
+			return fmt.Sprintf("%q", v)
+		},
+	}
+}
+
+// renderTemplate renders a gotmpl file with the given config data and returns the output.
+func renderTemplate(t *testing.T, filename string, data map[string]interface{}) string {
+	t.Helper()
+	tmplPath := filepath.Join(deployPkoDir(), filename)
+	content, err := os.ReadFile(tmplPath)
+	if err != nil {
+		t.Fatalf("failed to read template %s: %v", tmplPath, err)
+	}
+
+	tmpl, err := template.New(filename).Funcs(templateFuncMap()).Parse(string(content))
+	if err != nil {
+		t.Fatalf("failed to parse template %s: %v", filename, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("failed to execute template %s: %v", filename, err)
+	}
+	return buf.String()
+}
+
+// parseYAMLDocument parses a single YAML document into a map.
+func parseYAMLDocument(t *testing.T, data string) map[string]interface{} {
+	t.Helper()
+	var result map[string]interface{}
+	if err := yaml.Unmarshal([]byte(data), &result); err != nil {
+		t.Fatalf("failed to parse YAML: %v\nContent:\n%s", err, data)
+	}
+	return result
+}
+
+// defaultConfig returns a production-like config with populated arrays.
+func defaultConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"config": map[string]interface{}{
+			"image":                            "quay.io/example/pagerduty-operator:test",
+			"fedramp":                          "false",
+			"acknowledgeTimeout":               21600,
+			"resolveTimeout":                   0,
+			"escalationPolicy":                 "PTEST123",
+			"escalationPolicySilent":           "PSILENT1",
+			"servicePrefix":                    "osd",
+			"scaleTestEscalationPolicy":        "PSCALE01",
+			"scaleTestServicePrefix":           "osd-scale-test",
+			"serviceOrchestrationEnabled":      "true",
+			"serviceOrchestrationRuleConfigmap": "osd-serviceorchestration",
+			"alertGroupingType":                "time",
+			"alertGroupingTimeout":             300,
+			"silentAlertLegalEntityIds": []string{
+				"1aV37K1VQv2zSStwSkdwBNOUBGI",
+				"2Mo8exhgEA5ir1lsVypXUb9v902",
+			},
+			"scaleTestLegalEntityIds": []string{
+				"1ep4WsPDKikDQCFLsi2yKdzH8xB",
+			},
+			"serviceOrchestrationRules":        `{"orchestration_path":{"catch_all":{"actions":{}},"sets":[{"id":"start","rules":[{"actions":{"suppress":true},"conditions":[{"expression":"event.severity matches 'Warning'"}]}]}],"type":"service"}}`,
+			"rhInfraServiceOrchestrationRules": `{"orchestration_path":{"catch_all":{"actions":{}},"sets":[{"id":"start","rules":[{"actions":{"suppress":true},"conditions":[{"expression":"event.severity matches 'Warning'"}]},{"actions":{"priority":"PDPJP5Q"},"conditions":[]}]}],"type":"service"}}`,
+		},
+	}
+}
+
+// emptyArraysConfig returns a config with empty arrays for edge-case testing.
+func emptyArraysConfig() map[string]interface{} {
+	config := defaultConfig()
+	inner := config["config"].(map[string]interface{})
+	inner["silentAlertLegalEntityIds"] = []string{}
+	inner["scaleTestLegalEntityIds"] = []string{}
+	inner["servicePrefix"] = "osdint"
+	return config
+}
+
+// fedrampConfig returns a config with fedramp enabled.
+func fedrampConfig() map[string]interface{} {
+	config := defaultConfig()
+	config["config"].(map[string]interface{})["fedramp"] = "true"
+	return config
+}
+
+// orchestrationDisabledConfig returns a config with service orchestration disabled.
+func orchestrationDisabledConfig() map[string]interface{} {
+	config := defaultConfig()
+	inner := config["config"].(map[string]interface{})
+	inner["serviceOrchestrationEnabled"] = "false"
+	inner["serviceOrchestrationRules"] = "{}"
+	inner["rhInfraServiceOrchestrationRules"] = "{}"
+	return config
+}
+
+func TestDeploymentGotmpl(t *testing.T) {
+	output := renderTemplate(t, "Deployment-pagerduty-operator.yaml.gotmpl", defaultConfig())
+	doc := parseYAMLDocument(t, output)
+
+	if doc["kind"] != "Deployment" {
+		t.Errorf("expected kind=Deployment, got %v", doc["kind"])
+	}
+
+	metadata := doc["metadata"].(map[string]interface{})
+	if metadata["name"] != "pagerduty-operator" {
+		t.Errorf("expected name=pagerduty-operator, got %v", metadata["name"])
+	}
+	if metadata["namespace"] != "pagerduty-operator" {
+		t.Errorf("expected namespace=pagerduty-operator, got %v", metadata["namespace"])
+	}
+
+	annotations := metadata["annotations"].(map[string]interface{})
+	if annotations["package-operator.run/phase"] != "deploy" {
+		t.Errorf("expected phase=deploy, got %v", annotations["package-operator.run/phase"])
+	}
+
+	if !strings.Contains(output, "quay.io/example/pagerduty-operator:test") {
+		t.Error("expected config.image to be substituted in Deployment")
+	}
+
+	if !strings.Contains(output, "value: 'false'") {
+		t.Error("expected config.fedramp to be substituted in FEDRAMP env var")
+	}
+}
+
+func TestDeploymentGotmpl_Fedramp(t *testing.T) {
+	output := renderTemplate(t, "Deployment-pagerduty-operator.yaml.gotmpl", fedrampConfig())
+
+	if !strings.Contains(output, "value: 'true'") {
+		t.Error("expected FEDRAMP env var to be 'true' when fedramp config is true")
+	}
+}
+
+func TestPDIOsdGotmpl(t *testing.T) {
+	output := renderTemplate(t, "PagerDutyIntegration-osd.yaml.gotmpl", defaultConfig())
+	doc := parseYAMLDocument(t, output)
+
+	if doc["kind"] != "PagerDutyIntegration" {
+		t.Errorf("expected kind=PagerDutyIntegration, got %v", doc["kind"])
+	}
+
+	metadata := doc["metadata"].(map[string]interface{})
+	if metadata["name"] != "osd" {
+		t.Errorf("expected name=osd, got %v", metadata["name"])
+	}
+
+	annotations := metadata["annotations"].(map[string]interface{})
+	if annotations["package-operator.run/phase"] != "integrations" {
+		t.Errorf("expected phase=integrations, got %v", annotations["package-operator.run/phase"])
+	}
+
+	spec := doc["spec"].(map[string]interface{})
+
+	if spec["escalationPolicy"] != "PTEST123" {
+		t.Errorf("expected escalationPolicy=PTEST123, got %v", spec["escalationPolicy"])
+	}
+	if spec["servicePrefix"] != "osd" {
+		t.Errorf("expected servicePrefix=osd, got %v", spec["servicePrefix"])
+	}
+
+	// Verify serviceOrchestration block is present
+	orch := spec["serviceOrchestration"].(map[string]interface{})
+	// The gotmpl renders enabled: {{ .config.serviceOrchestrationEnabled }} which YAML
+	// may parse as boolean true or string "true" depending on the value
+	if fmt.Sprintf("%v", orch["enabled"]) != "true" {
+		t.Errorf("expected serviceOrchestration.enabled=true, got %v", orch["enabled"])
+	}
+
+	// Verify alertGroupingParameters block is present
+	alertGrouping := spec["alertGroupingParameters"].(map[string]interface{})
+	if alertGrouping["type"] != "time" {
+		t.Errorf("expected alertGroupingParameters.type=time, got %v", alertGrouping["type"])
+	}
+}
+
+func TestPDIOsdGotmpl_ArrayRendering(t *testing.T) {
+	output := renderTemplate(t, "PagerDutyIntegration-osd.yaml.gotmpl", defaultConfig())
+
+	// scaleTestLegalEntityIds should render as JSON array
+	if !strings.Contains(output, `["1ep4WsPDKikDQCFLsi2yKdzH8xB"]`) {
+		t.Error("expected scaleTestLegalEntityIds to render as JSON array")
+	}
+
+	// silentAlertLegalEntityIds should render as JSON array
+	if !strings.Contains(output, `["1aV37K1VQv2zSStwSkdwBNOUBGI","2Mo8exhgEA5ir1lsVypXUb9v902"]`) {
+		t.Error("expected silentAlertLegalEntityIds to render as JSON array")
+	}
+}
+
+func TestPDIOsdGotmpl_EmptyArrays(t *testing.T) {
+	output := renderTemplate(t, "PagerDutyIntegration-osd.yaml.gotmpl", emptyArraysConfig())
+
+	// Empty arrays should render as []
+	if !strings.Contains(output, "[]") {
+		t.Error("expected empty arrays to render as []")
+	}
+
+	// Should still be valid YAML
+	parseYAMLDocument(t, output)
+}
+
+func TestPDISilentGotmpl(t *testing.T) {
+	output := renderTemplate(t, "PagerDutyIntegration-osd-silent.yaml.gotmpl", defaultConfig())
+	doc := parseYAMLDocument(t, output)
+
+	metadata := doc["metadata"].(map[string]interface{})
+	if metadata["name"] != "osd-silent" {
+		t.Errorf("expected name=osd-silent, got %v", metadata["name"])
+	}
+
+	spec := doc["spec"].(map[string]interface{})
+
+	// Should use escalationPolicySilent
+	if spec["escalationPolicy"] != "PSILENT1" {
+		t.Errorf("expected escalationPolicy=PSILENT1, got %v", spec["escalationPolicy"])
+	}
+
+	// servicePrefix should have -silent suffix
+	if spec["servicePrefix"] != "osd-silent" {
+		t.Errorf("expected servicePrefix=osd-silent, got %v", spec["servicePrefix"])
+	}
+
+	// Should NOT have serviceOrchestration block
+	if _, ok := spec["serviceOrchestration"]; ok {
+		t.Error("osd-silent should NOT have serviceOrchestration block")
+	}
+
+	// Should NOT have alertGroupingParameters block
+	if _, ok := spec["alertGroupingParameters"]; ok {
+		t.Error("osd-silent should NOT have alertGroupingParameters block")
+	}
+}
+
+func TestPDISilentGotmpl_SilentIdsInValues(t *testing.T) {
+	output := renderTemplate(t, "PagerDutyIntegration-osd-silent.yaml.gotmpl", defaultConfig())
+	doc := parseYAMLDocument(t, output)
+
+	spec := doc["spec"].(map[string]interface{})
+	selector := spec["clusterDeploymentSelector"].(map[string]interface{})
+	expressions := selector["matchExpressions"].([]interface{})
+
+	// Find the silent alert legal entity ID expression — should use operator: In
+	for _, expr := range expressions {
+		e := expr.(map[string]interface{})
+		if e["key"] == "api.openshift.com/legal-entity-id" && e["operator"] == "In" {
+			return // Found the expected In operator for silent IDs
+		}
+	}
+	t.Error("expected legal-entity-id matchExpression with operator: In for silent alert IDs")
+}
+
+func TestPDIScaleTestGotmpl(t *testing.T) {
+	output := renderTemplate(t, "PagerDutyIntegration-osd-scale-test.yaml.gotmpl", defaultConfig())
+	doc := parseYAMLDocument(t, output)
+
+	metadata := doc["metadata"].(map[string]interface{})
+	if metadata["name"] != "osd-scale-test" {
+		t.Errorf("expected name=osd-scale-test, got %v", metadata["name"])
+	}
+
+	spec := doc["spec"].(map[string]interface{})
+
+	if spec["escalationPolicy"] != "PSCALE01" {
+		t.Errorf("expected escalationPolicy=PSCALE01, got %v", spec["escalationPolicy"])
+	}
+	if spec["servicePrefix"] != "osd-scale-test" {
+		t.Errorf("expected servicePrefix=osd-scale-test, got %v", spec["servicePrefix"])
+	}
+
+	// scaleTestLegalEntityIds should use operator: In
+	selector := spec["clusterDeploymentSelector"].(map[string]interface{})
+	expressions := selector["matchExpressions"].([]interface{})
+
+	for _, expr := range expressions {
+		e := expr.(map[string]interface{})
+		if e["key"] == "api.openshift.com/legal-entity-id" && e["operator"] == "In" {
+			return
+		}
+	}
+	t.Error("expected legal-entity-id matchExpression with operator: In for scale test IDs")
+}
+
+func TestConfigMapGotmpl(t *testing.T) {
+	output := renderTemplate(t, "ConfigMap-osd-serviceorchestration.yaml.gotmpl", defaultConfig())
+	doc := parseYAMLDocument(t, output)
+
+	if doc["kind"] != "ConfigMap" {
+		t.Errorf("expected kind=ConfigMap, got %v", doc["kind"])
+	}
+
+	metadata := doc["metadata"].(map[string]interface{})
+	if metadata["name"] != "osd-serviceorchestration" {
+		t.Errorf("expected name=osd-serviceorchestration, got %v", metadata["name"])
+	}
+
+	annotations := metadata["annotations"].(map[string]interface{})
+	if annotations["package-operator.run/phase"] != "integrations" {
+		t.Errorf("expected phase=integrations, got %v", annotations["package-operator.run/phase"])
+	}
+
+	// Verify both data keys are present
+	data := doc["data"].(map[string]interface{})
+	if _, ok := data["service-orchestration.json"]; !ok {
+		t.Error("expected data key 'service-orchestration.json'")
+	}
+	if _, ok := data["rh-infra-service-orchestration.json"]; !ok {
+		t.Error("expected data key 'rh-infra-service-orchestration.json'")
+	}
+
+	// Verify JSON rules are present in the rendered output
+	if !strings.Contains(output, "orchestration_path") {
+		t.Error("expected service orchestration rules JSON to be rendered")
+	}
+}
+
+func TestConfigMapGotmpl_EmptyRules(t *testing.T) {
+	output := renderTemplate(t, "ConfigMap-osd-serviceorchestration.yaml.gotmpl", orchestrationDisabledConfig())
+
+	// Should still be valid YAML
+	parseYAMLDocument(t, output)
+
+	// Empty rules should render as quoted empty JSON object
+	if !strings.Contains(output, "{}") {
+		t.Error("expected empty orchestration rules to render as {}")
+	}
+}
+
+func TestAllGotmplsRenderWithDefaults(t *testing.T) {
+	dir := deployPkoDir()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.gotmpl"))
+	if err != nil {
+		t.Fatalf("failed to glob gotmpls: %v", err)
+	}
+
+	if len(matches) == 0 {
+		t.Fatal("no .gotmpl files found in deploy_pko/")
+	}
+
+	config := defaultConfig()
+	for _, match := range matches {
+		filename := filepath.Base(match)
+		t.Run(filename, func(t *testing.T) {
+			output := renderTemplate(t, filename, config)
+			parseYAMLDocument(t, output)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add Go unit tests (`pkg/pko/template_test.go`) validating all 5 gotmpls in `deploy_pko/` render correctly
- Add `test.template` section to `manifest.yaml` with 5 test contexts, generating `.test-fixtures/` snapshot baselines via `kubectl-package validate`
- Follows the pattern established by deadmanssnitch-operator (PR #273)

### Test coverage

11 tests across 5 configurations (default/production, integration, empty-arrays, fedramp, orchestration-disabled):

- Deployment: image substitution, FEDRAMP env var toggling
- PDI-osd: escalation policy, serviceOrchestration block, alertGroupingParameters, array rendering via `toJson`
- PDI-osd-silent: uses silent escalation policy, `-silent` prefix, correctly omits serviceOrchestration/alertGrouping
- PDI-osd-scale-test: scale test escalation policy/prefix, legal entity ID selector uses `operator: In`
- ConfigMap: orchestration rules rendered via `quote` filter, both data keys present
- Sanity: all gotmpls produce valid YAML with default config

### Snapshot fixtures

`kubectl-package validate` generates `.test-fixtures/` with rendered output for each test context (13 resources x 5 contexts = 65 fixture files).

Ref: https://issues.redhat.com/browse/SREP-3261

## Test plan

- [x] `go test ./pkg/pko/...` — all 11 tests pass
- [x] `make test` — full suite passes
- [x] `kubectl-package validate deploy_pko/` — package validates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)