### PR TITLE
Add .dockerignore to exclude test fixtures from PKO image

### DIFF
--- a/deploy_pko/.dockerignore
+++ b/deploy_pko/.dockerignore
@@ -1,0 +1,1 @@
+.test-fixtures


### PR DESCRIPTION
## Summary
- Adds `deploy_pko/.dockerignore` excluding `.test-fixtures` from the PKO OCI image build context
- Fixes `Duplicate Object` errors in PKO manager when deploying the ClusterPackage on integration hive

## Root cause
Buildah's `COPY *` matches dotfiles and dotdirs (contrary to Go's `filepath.Match` docs). The `.test-fixtures/` directory contents are flattened into the image, creating duplicate objects (e.g., both `Cleanup-OLM-Job.yaml` and `default/Cleanup-OLM-Job.yaml`). Konflux's `buildah-oci-ta` task natively supports `.dockerignore` in the build context directory.

## Test plan
- [x] Built PKO image locally with fix — verified `.test-fixtures/` excluded
- [ ] Konflux rebuild produces working ClusterPackage
- [ ] PKO manager logs clear of Duplicate Object errors for pagerduty-operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)