### PR TITLE
SREP-3261: Quote alertGroupingType in PKO template to prevent null

### DIFF
--- a/deploy_pko/.test-fixtures/default/PagerDutyIntegration-osd.yaml
+++ b/deploy_pko/.test-fixtures/default/PagerDutyIntegration-osd.yaml
@@ -20,7 +20,7 @@ spec:
       name: osd-serviceorchestration
       namespace: pagerduty-operator
   alertGroupingParameters:
-    type: time
+    type: "time"
     config:
       timeout: 300
   clusterDeploymentSelector:

--- a/deploy_pko/.test-fixtures/empty-arrays/PagerDutyIntegration-osd.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/PagerDutyIntegration-osd.yaml
@@ -20,7 +20,7 @@ spec:
       name: osd-serviceorchestration
       namespace: pagerduty-operator
   alertGroupingParameters:
-    type: 
+    type: ""
     config:
       timeout: 0
   clusterDeploymentSelector:

--- a/deploy_pko/.test-fixtures/fedramp/PagerDutyIntegration-osd.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/PagerDutyIntegration-osd.yaml
@@ -20,7 +20,7 @@ spec:
       name: osd-serviceorchestration
       namespace: pagerduty-operator
   alertGroupingParameters:
-    type: 
+    type: ""
     config:
       timeout: 0
   clusterDeploymentSelector:

--- a/deploy_pko/.test-fixtures/integration/PagerDutyIntegration-osd.yaml
+++ b/deploy_pko/.test-fixtures/integration/PagerDutyIntegration-osd.yaml
@@ -20,7 +20,7 @@ spec:
       name: osd-serviceorchestration
       namespace: pagerduty-operator
   alertGroupingParameters:
-    type: 
+    type: ""
     config:
       timeout: 0
   clusterDeploymentSelector:

--- a/deploy_pko/.test-fixtures/orchestration-disabled/PagerDutyIntegration-osd.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/PagerDutyIntegration-osd.yaml
@@ -20,7 +20,7 @@ spec:
       name: osd-serviceorchestration
       namespace: pagerduty-operator
   alertGroupingParameters:
-    type: 
+    type: ""
     config:
       timeout: 0
   clusterDeploymentSelector:

--- a/deploy_pko/PagerDutyIntegration-osd.yaml.gotmpl
+++ b/deploy_pko/PagerDutyIntegration-osd.yaml.gotmpl
@@ -20,7 +20,7 @@ spec:
       name: {{ .config.serviceOrchestrationRuleConfigmap }}
       namespace: pagerduty-operator
   alertGroupingParameters:
-    type: {{ .config.alertGroupingType }}
+    type: "{{ .config.alertGroupingType }}"
     config:
       timeout: {{ .config.alertGroupingTimeout }}
   clusterDeploymentSelector:


### PR DESCRIPTION
## Summary

- Fix PKO `ClusterPackage` stuck in `Progressing` state due to CRD validation error on the `osd` `PagerDutyIntegration`
- When `alertGroupingType` is empty string, the Go template `{{ .config.alertGroupingType }}` renders a bare YAML value parsed as `null`, but the CRD schema requires `type: string`
- Quote the template value so empty strings render as `""` instead of YAML null

## Error observed

```
Phase "integrations", PagerDutyIntegration pagerduty-operator/osd:
PagerDutyIntegration.pagerduty.openshift.io "osd" is invalid:
spec.alertGroupingParameters.type: Invalid value: "null":
spec.alertGroupingParameters.type in body must be of type string: "null"
```

## Changes

- `deploy_pko/PagerDutyIntegration-osd.yaml.gotmpl`: Quote `alertGroupingType` template value
- `deploy_pko/.test-fixtures/*/PagerDutyIntegration-osd.yaml`: Update snapshot fixtures to match

## Test plan

- [x] `make test` passes (including PKO template snapshot tests)
- [x] `make docker-build` passes
- [ ] Validate on staging hive after merge — ClusterPackage should reach `Available=True`

Created with assistance from Claude 🤖 <claude@anthropic.com>