### PR TITLE
Remove ttlSecondsAfterFinished from OLM cleanup Job

### DIFF
--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/.test-fixtures/empty-arrays/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/.test-fixtures/integration/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/integration/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/.test-fixtures/orchestration-disabled/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:


### PR DESCRIPTION
## Summary

- Remove `ttlSecondsAfterFinished: 100` from the OLM cleanup Job in the PKO package
- The TTL caused an infinite re-creation loop: the Job completes, Kubernetes deletes it after 100s, PKO detects the missing resource and re-creates it, repeat
- Without the TTL, the completed Job persists and PKO stops re-creating it

## Problem

The OLM cleanup Job (`deploy_pko/Cleanup-OLM-Job.yaml`) was running continuously on a ~100-second cycle on all hives. The interaction between `ttlSecondsAfterFinished` and PKO's reconciliation loop created this behavior:

1. PKO deploys the Job as part of the `cleanup-deploy` phase
2. Job runs, completes (deletes OLM resources that are already gone)
3. After 100 seconds, Kubernetes TTL controller deletes the completed Job
4. PKO's reconciler detects the Job is missing from desired state
5. PKO re-creates the Job
6. Go to step 2

This was confirmed via cluster events showing pods cycling every ~100 seconds:
`olm-cleanup-zzd4v` → `olm-cleanup-h952f` → `olm-cleanup-kplrm` → `olm-cleanup-vzmnn` → `olm-cleanup-mjv8w`

## Fix

Removing `ttlSecondsAfterFinished` allows the completed Job to persist. PKO sees the resource exists and matches desired state, so it stops re-creating it. The Job will still run once when a new package version is deployed (new ClusterObjectSet), which is the intended one-time cleanup behavior.

## Test plan

- [x] `make test` passes
- [x] `make docker-build` passes
- [ ] Verify on a staging hive that the Job runs once and stays in `Complete` status without being re-created

Created with assistance from Claude 🤖 <claude@anthropic.com>