### PR TITLE
Remove ttlSecondsAfterFinished from OLM cleanup Job

### DIFF
--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/.test-fixtures/empty-arrays/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/.test-fixtures/integration/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/integration/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/.test-fixtures/orchestration-disabled/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -56,7 +56,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:


### PR DESCRIPTION
## Summary

- Remove `ttlSecondsAfterFinished: 100` from the OLM cleanup Job spec and all PKO test fixtures

## Problem

The OLM cleanup Job has `ttlSecondsAfterFinished: 100`, which causes Kubernetes to garbage-collect the completed Job after 100 seconds. When PKO detects the Job is missing from the cluster, it recreates it, causing the cleanup script to run again. This creates a loop where the Job runs repeatedly rather than running once and staying completed.

## Fix

Remove `ttlSecondsAfterFinished` entirely so the Job is not garbage-collected. PKO manages the Job lifecycle directly — the Job runs once during the cleanup phase and remains in a completed state.

## Test plan

- [ ] Verify PKO template tests pass (`make test`)
- [ ] Verify the OLM cleanup Job runs once and does not restart on a test cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified Kubernetes job cleanup behavior to prevent automatic removal of completed jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->