### PR TITLE
SREP-4890: Fix waitForIncidentsToResolve never properly waiting or timing out

### DIFF
--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -594,37 +594,31 @@ func (c *SvcClient) getUnresolvedAlerts(incidentId string) ([]pdApi.IncidentAler
 	return alerts.Alerts, err
 }
 
-// waitForIncidentsToResolve checks if all incidents have been resolved every 2 seconds,
-// waiting for a maximum of maxWait
+// waitForIncidentsToResolve polls for unresolved incidents every waitStep,
+// returning nil when all are resolved or an error if maxWait is exceeded.
 func (c *SvcClient) waitForIncidentsToResolve(data *Data, maxWait time.Duration) error {
 	waitStep := 2 * time.Second
-	incidents, err := c.getUnresolvedIncidents(data)
-	if err != nil {
-		return fmt.Errorf("unable to get unresolved incidents: %w", err)
-	}
-
-	totalIncidents := len(incidents)
-
 	start := time.Now()
-	for _, incident := range incidents {
+
+	for {
+		incidents, err := c.getUnresolvedIncidents(data)
+		if err != nil {
+			return fmt.Errorf("unable to get unresolved incidents: %w", err)
+		}
+
+		if len(incidents) == 0 {
+			return nil
+		}
+
 		if time.Since(start) > maxWait {
-			return fmt.Errorf("timed out waiting for %d incidents to resolve, %d left: %v",
-				totalIncidents,
+			return fmt.Errorf("timed out waiting for %d incidents to resolve: %v",
 				len(incidents),
 				parseIncidentNumbers(incidents),
 			)
 		}
 
-		if incident.AlertCounts.Triggered > 0 {
-			c.Delay(waitStep)
-			incidents, err = c.getUnresolvedIncidents(data)
-			if err != nil {
-				return fmt.Errorf("unable to get unresolved incidents: %w", err)
-			}
-		}
+		c.Delay(waitStep)
 	}
-
-	return nil
 }
 
 // parseIncidentNumbers returns a slice of PagerDuty incident numbers

--- a/pkg/pagerduty/service_mock.go
+++ b/pkg/pagerduty/service_mock.go
@@ -268,18 +268,19 @@ func (m *mockApi) setupDefaultServiceHandlers() {
 	}
 }
 
-// setupDefaultListIncidentsHandler sets up a handler to respond to listing incidents
+// setupDefaultListIncidentsHandler sets up a handler to respond to listing incidents.
+// Reads from m.State.Incidents at request time so tests can modify state dynamically.
 func (m *mockApi) setupDefaultListIncidentsHandler() {
-	var incidents []pd.Incident
-	for _, inc := range m.State.Incidents {
-		incidents = append(incidents, *inc)
-	}
-
-	incidentsData := map[string][]pd.Incident{
-		"incidents": incidents,
-	}
-
 	m.mux.HandleFunc("/incidents", func(w http.ResponseWriter, r *http.Request) {
+		var incidents []pd.Incident
+		for _, inc := range m.State.Incidents {
+			incidents = append(incidents, *inc)
+		}
+
+		incidentsData := map[string][]pd.Incident{
+			"incidents": incidents,
+		}
+
 		filteredIncidentsData := processListIncidentsQueryParams(r.URL.Query(), incidentsData)
 
 		resp, err := json.Marshal(filteredIncidentsData)
@@ -531,7 +532,21 @@ func (m *mockApi) setupV2EventsHandler() {
 			return
 		}
 
-		// TODO: Actually resolve the alerts
+		if eventReq.Action == "resolve" {
+			var remaining []*pd.Incident
+			for _, inc := range m.State.Incidents {
+				if inc.Status != "triggered" {
+					remaining = append(remaining, inc)
+				} else {
+					inc.Status = "resolved"
+					inc.AlertCounts.Triggered = 0
+					inc.AlertCounts.Resolved = inc.AlertCounts.All
+					remaining = append(remaining, inc)
+				}
+			}
+			m.State.Incidents = remaining
+		}
+
 		success.DedupKey = eventReq.DedupKey
 		resp, err := json.Marshal(success)
 		if err != nil {

--- a/pkg/pagerduty/service_test.go
+++ b/pkg/pagerduty/service_test.go
@@ -742,7 +742,7 @@ func TestSvcClient_ApplyServiceOrchestrationRule(t *testing.T) {
 }
 
 func TestSvcClient_WaitForIncidentsToResolve(t *testing.T) {
-	t.Run("No incidents for unknown service", func(t *testing.T) {
+	t.Run("0 incidents returns nil immediately", func(t *testing.T) {
 		mock := defaultMockApi()
 		defer mock.cleanup()
 
@@ -750,12 +750,66 @@ func TestSvcClient_WaitForIncidentsToResolve(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("Completes with default mock state", func(t *testing.T) {
+	t.Run("1 unresolved incident times out", func(t *testing.T) {
 		mock := defaultMockApi()
 		defer mock.cleanup()
 
+		mock.Client.Delay = func(d time.Duration) {
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		err := mock.Client.waitForIncidentsToResolve(&Data{ServiceID: mockServiceId}, 30*time.Millisecond)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "timed out waiting for")
+	})
+
+	t.Run("3 unresolved incidents times out", func(t *testing.T) {
+		mock := defaultMockApi()
+		defer mock.cleanup()
+
+		mock.State.Incidents = append(mock.State.Incidents,
+			&pdApi.Incident{
+				APIObject: pdApi.APIObject{ID: "INC3"},
+				Service:   pdApi.APIObject{ID: mockServiceId},
+				Status:    "triggered",
+				AlertCounts: pdApi.AlertCounts{
+					Triggered: 1,
+				},
+			},
+			&pdApi.Incident{
+				APIObject: pdApi.APIObject{ID: "INC4"},
+				Service:   pdApi.APIObject{ID: mockServiceId},
+				Status:    "triggered",
+				AlertCounts: pdApi.AlertCounts{
+					Triggered: 1,
+				},
+			},
+		)
+
+		mock.Client.Delay = func(d time.Duration) {
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		err := mock.Client.waitForIncidentsToResolve(&Data{ServiceID: mockServiceId}, 30*time.Millisecond)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "timed out waiting for")
+	})
+
+	t.Run("Incidents resolve during wait", func(t *testing.T) {
+		mock := defaultMockApi()
+		defer mock.cleanup()
+
+		callCount := 0
+		mock.Client.Delay = func(d time.Duration) {
+			callCount++
+			if callCount >= 2 {
+				mock.State.Incidents = nil
+			}
+		}
+
 		err := mock.Client.waitForIncidentsToResolve(&Data{ServiceID: mockServiceId}, 5*time.Second)
 		assert.Nil(t, err)
+		assert.GreaterOrEqual(t, callCount, 2)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Fix `waitForIncidentsToResolve` which used a `range` loop over a snapshot of incidents, causing it to never properly wait for resolution or time out
- Fix nil `Delay` function in test mock that would panic on delete/disable code paths
- Make incidents mock handler read state dynamically so tests can simulate incident resolution

## Bug

The function used `for _, incident := range incidents` and reassigned `incidents` inside the loop. Go evaluates `range` once at loop start — reassigning the variable does not restart iteration. The loop walked the original snapshot once and stopped.

With 1 incident (the common case): checked timeout (just started, passes), found Triggered > 0, waited 2s, re-fetched incidents (still unresolved), but the range only had 1 element — loop ended, returned success. The timeout never had a second chance to fire.

With 3+ incidents: same problem. Walked the original 3, stopped. Any still-unresolved incidents were silently ignored.

## Fix

Replace the `range` loop with a `for` loop that re-fetches from scratch each iteration:
1. Fetch unresolved incidents
2. If none, return success
3. If timeout exceeded, return error
4. Wait, then loop back to step 1

## Test plan
- [x] `TestSvcClient_WaitForIncidentsToResolve/0_incidents_returns_nil_immediately`
- [x] `TestSvcClient_WaitForIncidentsToResolve/1_unresolved_incident_times_out`
- [x] `TestSvcClient_WaitForIncidentsToResolve/3_unresolved_incidents_times_out`
- [x] `TestSvcClient_WaitForIncidentsToResolve/Incidents_resolve_during_wait`
- [x] All 13 existing pagerduty tests pass
- [x] All 5 controller tests pass
- [x] `make test` passes

REF: https://redhat.atlassian.net/browse/SREP-4890

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated incident resolution polling to continuously check for unresolved incidents until resolution or timeout is reached.

* **Tests**
  * Enhanced test coverage for incident resolution scenarios, including immediate success, timeout cases, and dynamic resolution during polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->