### PR TITLE
SREP-4885: Refactor FedRAMP config from global state to dependency injection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,25 +65,18 @@ func Name(servicePrefix, clusterDeploymentName, suffix string) string {
 	return servicePrefix + "-" + clusterDeploymentName + suffix
 }
 
-var isFedramp = false
-
-// SetIsFedramp gets the value of fedramp
-func SetIsFedramp() error {
+// ParseFedrampEnv reads the FEDRAMP environment variable and returns its
+// boolean value. Returns (false, nil) when the variable is unset.
+func ParseFedrampEnv() (bool, error) {
 	fedramp, ok := os.LookupEnv("FEDRAMP")
 	if !ok {
-		fedramp = "false"
+		return false, nil
 	}
 
 	fedrampBool, err := strconv.ParseBool(fedramp)
 	if err != nil {
-		return fmt.Errorf("invalid value for FedRAMP environment variable: %w", err)
+		return false, fmt.Errorf("invalid value for FedRAMP environment variable: %w", err)
 	}
 
-	isFedramp = fedrampBool
-	return nil
-}
-
-// IsFedramp returns value of isFedramp var
-func IsFedramp() bool {
-	return isFedramp
+	return fedrampBool, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFedrampEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		envValue  string
+		envSet    bool
+		expected  bool
+		expectErr bool
+	}{
+		{
+			name:     "unset env returns false",
+			envSet:   false,
+			expected: false,
+		},
+		{
+			name:     "true returns true",
+			envValue: "true",
+			envSet:   true,
+			expected: true,
+		},
+		{
+			name:     "false returns false",
+			envValue: "false",
+			envSet:   true,
+			expected: false,
+		},
+		{
+			name:     "TRUE returns true",
+			envValue: "TRUE",
+			envSet:   true,
+			expected: true,
+		},
+		{
+			name:     "1 returns true",
+			envValue: "1",
+			envSet:   true,
+			expected: true,
+		},
+		{
+			name:     "0 returns false",
+			envValue: "0",
+			envSet:   true,
+			expected: false,
+		},
+		{
+			name:      "invalid value returns error",
+			envValue:  "invalid",
+			envSet:    true,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envSet {
+				t.Setenv("FEDRAMP", tt.envValue)
+			}
+
+			result, err := ParseFedrampEnv()
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/controllers/pagerdutyintegration/clusterdeployment_created.go
+++ b/controllers/pagerdutyintegration/clusterdeployment_created.go
@@ -72,8 +72,8 @@ func (r *PagerDutyIntegrationReconciler) handleCreate(pdclient pd.Client, pdi *p
 		return r.Patch(context.TODO(), cd, baseToPatch)
 	}
 
-	clusterID := utils.GetClusterID(cd)
-	pdData, err := pd.NewData(pdi, clusterID, cd.Spec.BaseDomain)
+	clusterID := utils.GetClusterID(cd, r.IsFedramp)
+	pdData, err := pd.NewData(pdi, clusterID, cd.Spec.BaseDomain, r.IsFedramp)
 	if err != nil {
 		return err
 	}

--- a/controllers/pagerdutyintegration/clusterdeployment_deleted.go
+++ b/controllers/pagerdutyintegration/clusterdeployment_deleted.go
@@ -56,8 +56,8 @@ func (r *PagerDutyIntegrationReconciler) handleDelete(pdclient pd.Client, pdi *p
 		return nil
 	}
 
-	clusterID := utils.GetClusterID(cd)
-	pdData, err := pd.NewData(pdi, clusterID, cd.Spec.BaseDomain)
+	clusterID := utils.GetClusterID(cd, r.IsFedramp)
+	pdData, err := pd.NewData(pdi, clusterID, cd.Spec.BaseDomain, r.IsFedramp)
 	if err != nil {
 		return err
 	}

--- a/controllers/pagerdutyintegration/clusterdeployment_limited_support.go
+++ b/controllers/pagerdutyintegration/clusterdeployment_limited_support.go
@@ -21,8 +21,8 @@ func (r *PagerDutyIntegrationReconciler) handleLimitedSupport(pdclient pd.Client
 	}
 
 	// PagerDuty data
-	clusterID := utils.GetClusterID(cd)
-	pdData, err := pd.NewData(pdi, clusterID, cd.Spec.BaseDomain)
+	clusterID := utils.GetClusterID(cd, r.IsFedramp)
+	pdData, err := pd.NewData(pdi, clusterID, cd.Spec.BaseDomain, r.IsFedramp)
 	if err != nil {
 		return err
 	}

--- a/controllers/pagerdutyintegration/handleupdate.go
+++ b/controllers/pagerdutyintegration/handleupdate.go
@@ -46,7 +46,7 @@ func (r *PagerDutyIntegrationReconciler) handleUpdate(pdclient pd.Client, pdi *p
 	alertGroupingTimeout := cm.Data["ALERT_GROUPING_TIMEOUT"]
 
 	if alertGroupingType != pdi.Spec.AlertGroupingParameters.Type || alertGroupingTimeout != fmt.Sprintf("%d", pdi.Spec.AlertGroupingParameters.Config.Timeout) {
-		pdData, err := pd.NewData(pdi, cd.Spec.ClusterMetadata.ClusterID, cd.Spec.BaseDomain)
+		pdData, err := pd.NewData(pdi, cd.Spec.ClusterMetadata.ClusterID, cd.Spec.BaseDomain, r.IsFedramp)
 		if err != nil {
 			return err
 		}

--- a/controllers/pagerdutyintegration/pagerdutyintegration_controller.go
+++ b/controllers/pagerdutyintegration/pagerdutyintegration_controller.go
@@ -61,7 +61,8 @@ func (p pdiReconcileErrors) Error() string {
 // PagerDutyIntegrationReconciler reconciles a PagerDutyIntegration object
 type PagerDutyIntegrationReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme    *runtime.Scheme
+	IsFedramp bool
 
 	reqLogger logr.Logger
 	pdclient  func(APIKey string, controllerName string) pd.Client

--- a/controllers/pagerdutyintegration/pagerdutyintegration_controller_test.go
+++ b/controllers/pagerdutyintegration/pagerdutyintegration_controller_test.go
@@ -1086,9 +1086,10 @@ func TestReconcilePagerDutyIntegration(t *testing.T) {
 			defer mocks.mockCtrl.Finish()
 
 			rpdi := &PagerDutyIntegrationReconciler{
-				Client:   mocks.fakeKubeClient,
-				Scheme:   scheme.Scheme,
-				pdclient: func(s1 string, s2 string) pd.Client { return mocks.mockPDClient },
+				Client:    mocks.fakeKubeClient,
+				Scheme:    scheme.Scheme,
+				IsFedramp: false,
+				pdclient:  func(s1 string, s2 string) pd.Client { return mocks.mockPDClient },
 			}
 
 			// 1st run sets finalizer

--- a/controllers/pagerdutyintegration/serviceorchestration_handler.go
+++ b/controllers/pagerdutyintegration/serviceorchestration_handler.go
@@ -51,8 +51,8 @@ func (r *PagerDutyIntegrationReconciler) handleServiceOrchestration(pdclient pd.
 		return nil
 	}
 
-	clusterID := utils.GetClusterID(cd)
-	pdData, err := pd.NewData(pdi, clusterID, cd.Spec.BaseDomain)
+	clusterID := utils.GetClusterID(cd, r.IsFedramp)
+	pdData, err := pd.NewData(pdi, clusterID, cd.Spec.BaseDomain, r.IsFedramp)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -90,11 +90,12 @@ func main() {
 
 	// Print configuration info
 	printVersion()
-	if err := operatorconfig.SetIsFedramp(); err != nil {
-		setupLog.Error(err, "failed to get fedramp value")
+	fedrampEnabled, err := operatorconfig.ParseFedrampEnv()
+	if err != nil {
+		setupLog.Error(err, "failed to parse FEDRAMP environment variable")
 		os.Exit(1)
 	}
-	if operatorconfig.IsFedramp() {
+	if fedrampEnabled {
 		setupLog.Info("running in fedramp environment.")
 	}
 
@@ -113,8 +114,9 @@ func main() {
 	}
 
 	if err = (&pagerdutyintegration.PagerDutyIntegrationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		IsFedramp: fedrampEnabled,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PagerDutyIntegration")
 		os.Exit(1)

--- a/pkg/pagerduty/service.go
+++ b/pkg/pagerduty/service.go
@@ -158,11 +158,13 @@ type Data struct {
 	// Alert grouping related parameters
 	AlertGroupingType    string `json:"alert_grouping_type,omitempty"`
 	AlertGroupingTimeout uint   `'json:"alert_grouping_timeout,omitempty"`
+
+	IsFedramp bool
 }
 
 // NewData initializes a Data struct from a v1alpha1 PagerDutyIntegration spec
 // pdi.Spec.EscalationPolicy is required
-func NewData(pdi *pagerdutyv1alpha1.PagerDutyIntegration, clusterId string, baseDomain string) (*Data, error) {
+func NewData(pdi *pagerdutyv1alpha1.PagerDutyIntegration, clusterId string, baseDomain string, isFedramp bool) (*Data, error) {
 	if pdi.Spec.EscalationPolicy == "" {
 		return nil, fmt.Errorf("found empty escalation policy in the pagerdutyintegration spec")
 	}
@@ -174,6 +176,7 @@ func NewData(pdi *pagerdutyv1alpha1.PagerDutyIntegration, clusterId string, base
 		ServicePrefix:      pdi.Spec.ServicePrefix,
 		ClusterID:          clusterId,
 		BaseDomain:         baseDomain,
+		IsFedramp:          isFedramp,
 	}
 
 	if pdi.Spec.AlertGroupingParameters != nil {
@@ -640,7 +643,7 @@ func parseIncidentNumbers(incidents []pdApi.Incident) []uint {
 // generateServiceName checks if FedRamp is enabled. If it is, it returns
 // an anonymized PD service name.
 func generatePDServiceName(data *Data) string {
-	if config.IsFedramp() {
+	if data.IsFedramp {
 		return data.ServicePrefix + "-" + data.ClusterID
 	} else {
 		return data.ServicePrefix + "-" + data.ClusterID + "." + data.BaseDomain + "-hive-cluster"
@@ -650,7 +653,7 @@ func generatePDServiceName(data *Data) string {
 // generateServiceDescription checks if FedRamp is enabled. If it is, it returns
 // an empty PD service description
 func generatePDServiceDescription(data *Data) string {
-	if config.IsFedramp() {
+	if data.IsFedramp {
 		return ""
 	} else {
 		return data.ClusterID + " - A managed hive created cluster"

--- a/pkg/pagerduty/service_test.go
+++ b/pkg/pagerduty/service_test.go
@@ -1,13 +1,11 @@
 package pagerduty
 
 import (
-	"os"
 	"testing"
 	"time"
 
 	pdApi "github.com/PagerDuty/go-pagerduty"
 	pagerdutyv1alpha1 "github.com/openshift/pagerduty-operator/api/v1alpha1"
-	"github.com/openshift/pagerduty-operator/config"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,7 +100,7 @@ func TestNewData(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := NewData(test.pdi, "clusterId", "baseDomain")
+			_, err := NewData(test.pdi, "clusterId", "baseDomain", false)
 			if test.expectErr {
 				assert.NotNil(t, err)
 			} else {
@@ -110,6 +108,66 @@ func TestNewData(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewData_IsFedramp(t *testing.T) {
+	pdi := &pagerdutyv1alpha1.PagerDutyIntegration{
+		Spec: pagerdutyv1alpha1.PagerDutyIntegrationSpec{
+			EscalationPolicy: "POLICY123",
+		},
+	}
+
+	t.Run("isFedramp false is stored in Data", func(t *testing.T) {
+		data, err := NewData(pdi, "cluster1", "example.com", false)
+		assert.Nil(t, err)
+		assert.False(t, data.IsFedramp)
+	})
+
+	t.Run("isFedramp true is stored in Data", func(t *testing.T) {
+		data, err := NewData(pdi, "cluster1", "example.com", true)
+		assert.Nil(t, err)
+		assert.True(t, data.IsFedramp)
+	})
+}
+
+func TestGeneratePDServiceName(t *testing.T) {
+	t.Run("non-fedramp includes base domain", func(t *testing.T) {
+		data := &Data{
+			ServicePrefix: "osd",
+			ClusterID:     "my-cluster",
+			BaseDomain:    "example.com",
+			IsFedramp:     false,
+		}
+		assert.Equal(t, "osd-my-cluster.example.com-hive-cluster", generatePDServiceName(data))
+	})
+
+	t.Run("fedramp returns anonymized name", func(t *testing.T) {
+		data := &Data{
+			ServicePrefix: "osd",
+			ClusterID:     "abc123",
+			BaseDomain:    "example.com",
+			IsFedramp:     true,
+		}
+		assert.Equal(t, "osd-abc123", generatePDServiceName(data))
+	})
+}
+
+func TestGeneratePDServiceDescription(t *testing.T) {
+	t.Run("non-fedramp returns description", func(t *testing.T) {
+		data := &Data{
+			ClusterID: "my-cluster",
+			IsFedramp: false,
+		}
+		assert.Equal(t, "my-cluster - A managed hive created cluster", generatePDServiceDescription(data))
+	})
+
+	t.Run("fedramp returns empty description", func(t *testing.T) {
+		data := &Data{
+			ClusterID: "abc123",
+			IsFedramp: true,
+		}
+		assert.Equal(t, "", generatePDServiceDescription(data))
+	})
 }
 
 func TestParseSetClusterConfig(t *testing.T) {
@@ -835,68 +893,3 @@ func TestParseIncidentNumbers(t *testing.T) {
 	}
 }
 
-func TestGeneratePDServiceName(t *testing.T) {
-	data := &Data{
-		ServicePrefix: "prefix",
-		ClusterID:     "cluster123",
-		BaseDomain:    "example.com",
-	}
-
-	t.Run("Non-fedramp", func(t *testing.T) {
-		orig, had := os.LookupEnv("FEDRAMP")
-		os.Unsetenv("FEDRAMP")
-		_ = config.SetIsFedramp()
-		t.Cleanup(func() {
-			if had {
-				_ = os.Setenv("FEDRAMP", orig)
-			}
-			_ = config.SetIsFedramp()
-		})
-
-		result := generatePDServiceName(data)
-		assert.Equal(t, "prefix-cluster123.example.com-hive-cluster", result)
-	})
-
-	t.Run("Fedramp", func(t *testing.T) {
-		t.Setenv("FEDRAMP", "true")
-		_ = config.SetIsFedramp()
-		t.Cleanup(func() {
-			_ = config.SetIsFedramp()
-		})
-
-		result := generatePDServiceName(data)
-		assert.Equal(t, "prefix-cluster123", result)
-	})
-}
-
-func TestGeneratePDServiceDescription(t *testing.T) {
-	data := &Data{
-		ClusterID: "cluster123",
-	}
-
-	t.Run("Non-fedramp", func(t *testing.T) {
-		orig, had := os.LookupEnv("FEDRAMP")
-		os.Unsetenv("FEDRAMP")
-		_ = config.SetIsFedramp()
-		t.Cleanup(func() {
-			if had {
-				_ = os.Setenv("FEDRAMP", orig)
-			}
-			_ = config.SetIsFedramp()
-		})
-
-		result := generatePDServiceDescription(data)
-		assert.Equal(t, "cluster123 - A managed hive created cluster", result)
-	})
-
-	t.Run("Fedramp", func(t *testing.T) {
-		t.Setenv("FEDRAMP", "true")
-		_ = config.SetIsFedramp()
-		t.Cleanup(func() {
-			_ = config.SetIsFedramp()
-		})
-
-		result := generatePDServiceDescription(data)
-		assert.Equal(t, "", result)
-	})
-}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-logr/logr"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	"github.com/openshift/pagerduty-operator/config"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -133,8 +132,8 @@ func DeleteSecret(name string, namespace string, client client.Client, reqLogger
 	return nil
 }
 
-func GetClusterID(cd *hivev1.ClusterDeployment) string {
-	if config.IsFedramp() {
+func GetClusterID(cd *hivev1.ClusterDeployment, isFedramp bool) string {
+	if isFedramp {
 		cns := strings.Split(cd.Namespace, "-")
 		return cns[len(cns)-1]
 	} else {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,12 +1,10 @@
 package utils
 
 import (
-	"os"
 	"testing"
 
 	"github.com/go-logr/logr"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	"github.com/openshift/pagerduty-operator/config"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -267,49 +265,23 @@ func TestDeleteSecret(t *testing.T) {
 }
 
 func TestGetClusterID(t *testing.T) {
-	t.Run("Non-fedramp returns ClusterName", func(t *testing.T) {
-		orig, had := os.LookupEnv("FEDRAMP")
-		os.Unsetenv("FEDRAMP")
-		_ = config.SetIsFedramp()
-		t.Cleanup(func() {
-			if had {
-				_ = os.Setenv("FEDRAMP", orig)
-			}
-			_ = config.SetIsFedramp()
-		})
+	cd := &hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "uhc-production-abc123",
+		},
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName: "my-cluster-name",
+		},
+	}
 
-		cd := &hivev1.ClusterDeployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-cd",
-				Namespace: "uhc-production-abc123",
-			},
-			Spec: hivev1.ClusterDeploymentSpec{
-				ClusterName: "my-cluster",
-			},
-		}
-
-		result := GetClusterID(cd)
-		assert.Equal(t, "my-cluster", result)
+	t.Run("non-fedramp returns ClusterName", func(t *testing.T) {
+		result := GetClusterID(cd, false)
+		assert.Equal(t, "my-cluster-name", result)
 	})
 
-	t.Run("Fedramp returns namespace suffix", func(t *testing.T) {
-		t.Setenv("FEDRAMP", "true")
-		_ = config.SetIsFedramp()
-		t.Cleanup(func() {
-			_ = config.SetIsFedramp()
-		})
-
-		cd := &hivev1.ClusterDeployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-cd",
-				Namespace: "uhc-production-abc123",
-			},
-			Spec: hivev1.ClusterDeploymentSpec{
-				ClusterName: "my-cluster",
-			},
-		}
-
-		result := GetClusterID(cd)
+	t.Run("fedramp returns namespace suffix", func(t *testing.T) {
+		result := GetClusterID(cd, true)
 		assert.Equal(t, "abc123", result)
 	})
 }


### PR DESCRIPTION
## Summary

- Replace package-level mutable `var isFedramp` + `SetIsFedramp()`/`IsFedramp()` with a pure function `ParseFedrampEnv() (bool, error)` that returns the value without storing global state
- Add `IsFedramp bool` field to `PagerDutyIntegrationReconciler`, injected at startup in `main.go`
- Pass `isFedramp` explicitly through `utils.GetClusterID()` and `pd.NewData()` instead of reaching for the global
- Remove `config` package import from `pkg/utils/utils.go` (was only used for `IsFedramp()`)

## Why

The global mutable state pattern made tests fragile — they required manual env var save/restore and `SetIsFedramp()` calls, and parallel tests could race on the shared variable. With explicit parameter passing, tests simply pass `true` or `false` with no environment manipulation.

## Test plan

- [x] `go build ./...` compiles cleanly (compiler enforces all call sites updated)
- [x] `go test ./...` passes across all packages
- [x] `make lint` — 0 issues
- [x] New tests added:
  - `config/config_test.go` — `TestParseFedrampEnv` (7 subtests)
  - `pkg/utils/utils_test.go` — `TestGetClusterID` (2 subtests)
  - `pkg/pagerduty/service_test.go` — `TestNewData_IsFedramp`, `TestGeneratePDServiceName`, `TestGeneratePDServiceDescription` (6 subtests)
- [ ] CI pipeline passes

## Note

`handleupdate.go:49` uses `cd.Spec.ClusterMetadata.ClusterID` directly instead of `utils.GetClusterID(cd)` — a pre-existing inconsistency not introduced by this PR. Should be tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.ai/code)

Created with assistance from Claude 🤖 <claude@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved FedRAMP configuration handling to use environment variables exclusively, removing internal state dependencies
  * Enhanced PagerDuty integration with explicit FedRAMP awareness throughout cluster operations

* **Tests**
  * Added tests for FedRAMP environment variable parsing
  * Updated integration tests to verify FedRAMP-aware behavior in PagerDuty operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->