### PR TITLE
fix: symlink CLAUDE.md to AGENTS.md for SDLC conformance check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-@AGENTS.md
+AGENTS.md


### PR DESCRIPTION
## Summary

- `CLAUDE.md` contained `@AGENTS.md` (a Claude Code include directive), but the Konflux agentic SDLC conformance checker does `cat CLAUDE.md` and greps for required section headings — it doesn't resolve the `@` include, so it saw one line of text and failed
- Replaces the `@AGENTS.md` text with a symlink to `AGENTS.md`, so `cat CLAUDE.md` returns the full content at the filesystem level without duplicating it
- Fixes the two FAILs in `check-content-validation`:
  - `CLAUDE.md missing build/development commands section`
  - `CLAUDE.md missing architecture/overview section`

## Test plan

- [x] `pagerduty-operator-agentic-sdlc-check` Konflux pipeline passes on this PR