### PR TITLE
Scope ClusterRole to least-privilege verbs and resources

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786380870
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521
 
 ENV USER_UID=1001 \
     USER_NAME=pagerduty-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786380870
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -17,15 +17,38 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - create
 - apiGroups:
   - ""
   resources:
@@ -33,29 +56,18 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - "*"
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
   verbs:
-  - "get"
-  - "create"
+  - get
+  - create
 - apiGroups:
   - hive.openshift.io
-  attributeRestrictions: null
   resources:
   - clusterdeployments
   - clusterdeployments/finalizers
   - clusterdeployments/status
-  - syncsets
   verbs:
   - get
   - list
@@ -67,6 +79,9 @@ rules:
   resources:
   - syncsets
   verbs:
+  - get
+  - list
+  - watch
   - create
   - delete
 - apiGroups:
@@ -74,4 +89,5 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -49,6 +49,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ""
   resources:
@@ -91,3 +92,4 @@ rules:
   verbs:
   - get
   - create
+  - update

--- a/deploy_pko/.test-fixtures/default/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-pagerduty-operator.yaml
@@ -52,6 +52,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ''
   resources:
@@ -94,3 +95,4 @@ rules:
   verbs:
   - get
   - create
+  - update

--- a/deploy_pko/.test-fixtures/default/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-pagerduty-operator.yaml
@@ -18,46 +18,59 @@ rules:
   - watch
   - update
 - apiGroups:
-  - ""
+  - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
-  - ""
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ''
   resources:
   - namespaces
   verbs:
   - get
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - "*"
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
   verbs:
-  - "get"
-  - "create"
+  - get
+  - create
 - apiGroups:
   - hive.openshift.io
   resources:
   - clusterdeployments
   - clusterdeployments/finalizers
   - clusterdeployments/status
-  - syncsets
   verbs:
   - get
   - list
@@ -69,6 +82,9 @@ rules:
   resources:
   - syncsets
   verbs:
+  - get
+  - list
+  - watch
   - create
   - delete
 - apiGroups:
@@ -76,4 +92,5 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create

--- a/deploy_pko/.test-fixtures/empty-arrays/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/ClusterRole-pagerduty-operator.yaml
@@ -52,6 +52,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ''
   resources:
@@ -94,3 +95,4 @@ rules:
   verbs:
   - get
   - create
+  - update

--- a/deploy_pko/.test-fixtures/empty-arrays/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/empty-arrays/ClusterRole-pagerduty-operator.yaml
@@ -18,46 +18,59 @@ rules:
   - watch
   - update
 - apiGroups:
-  - ""
+  - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
-  - ""
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ''
   resources:
   - namespaces
   verbs:
   - get
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - "*"
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
   verbs:
-  - "get"
-  - "create"
+  - get
+  - create
 - apiGroups:
   - hive.openshift.io
   resources:
   - clusterdeployments
   - clusterdeployments/finalizers
   - clusterdeployments/status
-  - syncsets
   verbs:
   - get
   - list
@@ -69,6 +82,9 @@ rules:
   resources:
   - syncsets
   verbs:
+  - get
+  - list
+  - watch
   - create
   - delete
 - apiGroups:
@@ -76,4 +92,5 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRole-pagerduty-operator.yaml
@@ -52,6 +52,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ''
   resources:
@@ -94,3 +95,4 @@ rules:
   verbs:
   - get
   - create
+  - update

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRole-pagerduty-operator.yaml
@@ -18,46 +18,59 @@ rules:
   - watch
   - update
 - apiGroups:
-  - ""
+  - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
-  - ""
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ''
   resources:
   - namespaces
   verbs:
   - get
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - "*"
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
   verbs:
-  - "get"
-  - "create"
+  - get
+  - create
 - apiGroups:
   - hive.openshift.io
   resources:
   - clusterdeployments
   - clusterdeployments/finalizers
   - clusterdeployments/status
-  - syncsets
   verbs:
   - get
   - list
@@ -69,6 +82,9 @@ rules:
   resources:
   - syncsets
   verbs:
+  - get
+  - list
+  - watch
   - create
   - delete
 - apiGroups:
@@ -76,4 +92,5 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create

--- a/deploy_pko/.test-fixtures/integration/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/integration/ClusterRole-pagerduty-operator.yaml
@@ -52,6 +52,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ''
   resources:
@@ -94,3 +95,4 @@ rules:
   verbs:
   - get
   - create
+  - update

--- a/deploy_pko/.test-fixtures/integration/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/integration/ClusterRole-pagerduty-operator.yaml
@@ -18,46 +18,59 @@ rules:
   - watch
   - update
 - apiGroups:
-  - ""
+  - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
-  - ""
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ''
   resources:
   - namespaces
   verbs:
   - get
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - "*"
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
   verbs:
-  - "get"
-  - "create"
+  - get
+  - create
 - apiGroups:
   - hive.openshift.io
   resources:
   - clusterdeployments
   - clusterdeployments/finalizers
   - clusterdeployments/status
-  - syncsets
   verbs:
   - get
   - list
@@ -69,6 +82,9 @@ rules:
   resources:
   - syncsets
   verbs:
+  - get
+  - list
+  - watch
   - create
   - delete
 - apiGroups:
@@ -76,4 +92,5 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create

--- a/deploy_pko/.test-fixtures/orchestration-disabled/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/ClusterRole-pagerduty-operator.yaml
@@ -52,6 +52,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ''
   resources:
@@ -94,3 +95,4 @@ rules:
   verbs:
   - get
   - create
+  - update

--- a/deploy_pko/.test-fixtures/orchestration-disabled/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/.test-fixtures/orchestration-disabled/ClusterRole-pagerduty-operator.yaml
@@ -18,46 +18,59 @@ rules:
   - watch
   - update
 - apiGroups:
-  - ""
+  - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
-  - ""
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ''
   resources:
   - namespaces
   verbs:
   - get
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - "*"
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
   verbs:
-  - "get"
-  - "create"
+  - get
+  - create
 - apiGroups:
   - hive.openshift.io
   resources:
   - clusterdeployments
   - clusterdeployments/finalizers
   - clusterdeployments/status
-  - syncsets
   verbs:
   - get
   - list
@@ -69,6 +82,9 @@ rules:
   resources:
   - syncsets
   verbs:
+  - get
+  - list
+  - watch
   - create
   - delete
 - apiGroups:
@@ -76,4 +92,5 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create

--- a/deploy_pko/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/ClusterRole-pagerduty-operator.yaml
@@ -52,6 +52,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ''
   resources:
@@ -94,3 +95,4 @@ rules:
   verbs:
   - get
   - create
+  - update

--- a/deploy_pko/ClusterRole-pagerduty-operator.yaml
+++ b/deploy_pko/ClusterRole-pagerduty-operator.yaml
@@ -18,46 +18,59 @@ rules:
   - watch
   - update
 - apiGroups:
-  - ""
+  - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
-  - ""
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ''
   resources:
   - namespaces
   verbs:
   - get
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - "*"
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
   verbs:
-  - "get"
-  - "create"
+  - get
+  - create
 - apiGroups:
   - hive.openshift.io
   resources:
   - clusterdeployments
   - clusterdeployments/finalizers
   - clusterdeployments/status
-  - syncsets
   verbs:
   - get
   - list
@@ -69,6 +82,9 @@ rules:
   resources:
   - syncsets
   verbs:
+  - get
+  - list
+  - watch
   - create
   - delete
 - apiGroups:
@@ -76,4 +92,5 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create

--- a/manifests/02-role.yaml
+++ b/manifests/02-role.yaml
@@ -17,15 +17,38 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - create
 - apiGroups:
   - ""
   resources:
@@ -33,29 +56,18 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - "*"
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
   verbs:
-  - "get"
-  - "create"
+  - get
+  - create
 - apiGroups:
   - hive.openshift.io
-  attributeRestrictions: null
   resources:
   - clusterdeployments
   - clusterdeployments/finalizers
   - clusterdeployments/status
-  - syncsets
   verbs:
   - get
   - list
@@ -67,6 +79,9 @@ rules:
   resources:
   - syncsets
   verbs:
+  - get
+  - list
+  - watch
   - create
   - delete
 - apiGroups:
@@ -74,4 +89,5 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create

--- a/manifests/02-role.yaml
+++ b/manifests/02-role.yaml
@@ -49,6 +49,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ""
   resources:
@@ -91,3 +92,4 @@ rules:
   verbs:
   - get
   - create
+  - update


### PR DESCRIPTION
## Summary
- The operator ClusterRole used wildcard (`*`) verbs on core resources (pods, services, endpoints, persistentvolumeclaims, events, configmaps, secrets) and apps resources (deployments, daemonsets, replicasets, statefulsets), plus routes — far broader than what the controller exercises.
- Replaced all wildcard verbs with the minimal set actually needed per resource, based on code analysis of the controller, event handlers, and metrics setup.
- Dropped resources the controller never touches: `pods`, `endpoints`, `persistentvolumeclaims`, `deployments`, `daemonsets`, `replicasets`, `statefulsets`.
- Split `syncsets` out of the combined `clusterdeployments` rule so it only gets the verbs it needs (`get/list/watch/create/delete`) instead of inheriting `update/patch`.
- Changed `routes` from wildcard to `get, create`.
- Applied the same changes to `deploy/role.yaml`, `deploy_pko/ClusterRole`, `manifests/02-role.yaml`, and all five PKO test fixtures.
- Updated UBI base image tag to `9.8-1786987521` to align with boilerplate.

### Permission mapping

| Resource | Verbs | Reason |
|---|---|---|
| secrets | get, list, watch, create, delete | API key read, per-cluster PD secrets, watch triggers |
| configmaps | get, list, watch, create, update, delete | Per-cluster PD config CRUD, orchestration config, watch triggers |
| events | create, patch | Controller-runtime event recorder |
| services | get, create, update | Custom metrics endpoint (operator-custom-metrics create-or-update) |
| namespaces | get | _(unchanged)_ |
| syncsets | get, list, watch, create, delete | SyncSet CRUD + watch triggers |
| routes | get, create, update | Custom metrics endpoint (operator-custom-metrics create-or-update) |
| servicemonitors | get, create | _(unchanged)_ |
| clusterdeployments/* | get, list, watch, update, patch | _(unchanged)_ |
| pagerdutyintegrations/* | get, list, watch, update | _(unchanged)_ |

## Test plan
- [x] All unit tests pass (`go test ./...`)
- [x] PKO test fixtures updated and validated
- [ ] Verify operator starts without RBAC errors on a test cluster
- [ ] Verify reconciliation still creates/deletes secrets, syncsets, configmaps, and PD services correctly

[ROSAENG-61338](https://redhat.atlassian.net/browse/ROSAENG-61338)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Permissions**
  * Replaced broad deployment permissions with resource-specific access controls.
  * Restricted route operations to viewing, creation, and updates.
  * Added explicit permissions for secrets, configuration, events, services, namespaces, monitoring resources, and cluster deployments.
  * Removed unnecessary access to pods, endpoints, persistent volume claims, and workload resources.
  * Clarified synchronization resource permissions with explicit allowed operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
